### PR TITLE
Implemented fan preset icons

### DIFF
--- a/custom_components/hass_dyson/fan.py
+++ b/custom_components/hass_dyson/fan.py
@@ -162,6 +162,12 @@ class DysonFan(DysonEntity, FanEntity):
     coordinator: DysonDataUpdateCoordinator
     _attr_current_temperature: float | None
     _attr_target_temperature: float
+    _attr_translation_key = "dyson_fan"
+
+    # Preset variables for better maintenance
+    PRESET_MODE_AUTO = "auto"
+    PRESET_MODE_MANUAL = "manual"
+    PRESET_MODE_HEAT = "heat"
 
     def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
         """Initialize the Dyson fan entity with capability detection.
@@ -223,7 +229,7 @@ class DysonFan(DysonEntity, FanEntity):
 
         # Set up preset modes based on heating capability
         if self._has_heating:
-            self._attr_preset_modes = ["Auto", "Manual", "Heat"]
+            self._attr_preset_modes = [self.PRESET_MODE_AUTO, self.PRESET_MODE_MANUAL, self.PRESET_MODE_HEAT]
             # Add climate-specific attributes for heating devices
             self._attr_temperature_unit = UnitOfTemperature.CELSIUS
             self._attr_min_temp = 1
@@ -239,7 +245,7 @@ class DysonFan(DysonEntity, FanEntity):
             ]
             self._attr_hvac_mode = HVACMode.OFF
         else:
-            self._attr_preset_modes = ["Auto", "Manual"]
+            self._attr_preset_modes = [self.PRESET_MODE_AUTO, self.PRESET_MODE_MANUAL]
 
         # Initialize state attributes to ensure clean state
         self._attr_is_on = None  # Will be set properly in first coordinator update
@@ -330,14 +336,14 @@ class DysonFan(DysonEntity, FanEntity):
                     product_state, "hmod", "OFF"
                 )
                 if heating_mode == "HEAT":
-                    self._attr_preset_mode = "Heat"
+                    self._attr_preset_mode = self.PRESET_MODE_HEAT
                 elif is_auto_mode:
-                    self._attr_preset_mode = "Auto"
+                    self._attr_preset_mode = self.PRESET_MODE_AUTO
                 else:
-                    self._attr_preset_mode = "Manual"
+                    self._attr_preset_mode = self.PRESET_MODE_MANUAL
             else:
                 # Non-heating devices use simple Auto/Manual logic
-                self._attr_preset_mode = "Auto" if is_auto_mode else "Manual"
+                self._attr_preset_mode = self.PRESET_MODE_AUTO if is_auto_mode else self.PRESET_MODE_MANUAL
 
             # Update oscillation state from device data if supported
             if self._oscillation_supported:
@@ -618,11 +624,11 @@ class DysonFan(DysonEntity, FanEntity):
             return
 
         try:
-            if preset_mode == "Auto":
+            if preset_mode == self.PRESET_MODE_AUTO:
                 await self.coordinator.device.set_auto_mode(True)
-            elif preset_mode == "Manual":
+            elif preset_mode == self.PRESET_MODE_MANUAL:
                 await self.coordinator.device.set_auto_mode(False)
-            elif preset_mode == "Heat" and self._has_heating:
+            elif preset_mode == self.PRESET_MODE_MANUAL and self._has_heating:
                 # Enable heating mode
                 await self.coordinator.device.set_heating_mode("HEAT")
             else:

--- a/custom_components/hass_dyson/fan.py
+++ b/custom_components/hass_dyson/fan.py
@@ -229,7 +229,11 @@ class DysonFan(DysonEntity, FanEntity):
 
         # Set up preset modes based on heating capability
         if self._has_heating:
-            self._attr_preset_modes = [self.PRESET_MODE_AUTO, self.PRESET_MODE_MANUAL, self.PRESET_MODE_HEAT]
+            self._attr_preset_modes = [
+                self.PRESET_MODE_AUTO,
+                self.PRESET_MODE_MANUAL,
+                self.PRESET_MODE_HEAT,
+            ]
             # Add climate-specific attributes for heating devices
             self._attr_temperature_unit = UnitOfTemperature.CELSIUS
             self._attr_min_temp = 1
@@ -343,7 +347,9 @@ class DysonFan(DysonEntity, FanEntity):
                     self._attr_preset_mode = self.PRESET_MODE_MANUAL
             else:
                 # Non-heating devices use simple Auto/Manual logic
-                self._attr_preset_mode = self.PRESET_MODE_AUTO if is_auto_mode else self.PRESET_MODE_MANUAL
+                self._attr_preset_mode = (
+                    self.PRESET_MODE_AUTO if is_auto_mode else self.PRESET_MODE_MANUAL
+                )
 
             # Update oscillation state from device data if supported
             if self._oscillation_supported:

--- a/custom_components/hass_dyson/icons.json
+++ b/custom_components/hass_dyson/icons.json
@@ -1,0 +1,18 @@
+{
+    "entity": {
+        "fan": {
+            "dyson_fan": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "default": "mdi:fan",
+                        "state": {
+                            "auto": "mdi:fan-auto",
+                            "manual": "mdi:fan",
+                            "heat": "hdi:heat-wave"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom_components/hass_dyson/icons.json
+++ b/custom_components/hass_dyson/icons.json
@@ -8,7 +8,7 @@
                         "state": {
                             "auto": "mdi:fan-auto",
                             "manual": "mdi:fan",
-                            "heat": "hdi:heat-wave"
+                            "heat": "mdi:heat-wave"
                         }
                     }
                 }

--- a/custom_components/hass_dyson/icons.json
+++ b/custom_components/hass_dyson/icons.json
@@ -7,7 +7,6 @@
                         "default": "mdi:fan",
                         "state": {
                             "auto": "mdi:fan-auto",
-                            "manual": "mdi:fan",
                             "heat": "mdi:heat-wave"
                         }
                     }

--- a/custom_components/hass_dyson/translations/de.json
+++ b/custom_components/hass_dyson/translations/de.json
@@ -291,6 +291,19 @@
           }
         }
       }
+    },
+    "fan": {
+      "dyson_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manuell",
+              "heat": "Heizen"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/hass_dyson/translations/en.json
+++ b/custom_components/hass_dyson/translations/en.json
@@ -291,6 +291,19 @@
           }
         }
       }
+    },
+    "fan": {
+      "dyson_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manual",
+              "heat": "Heat"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/hass_dyson/translations/fr.json
+++ b/custom_components/hass_dyson/translations/fr.json
@@ -291,6 +291,19 @@
           }
         }
       }
+    },
+    "fan": {
+      "dyson_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manual",
+              "heat": "Heat"
+            }
+          }
+        }
+      }
     }
   },
   "services": {


### PR DESCRIPTION
This pull request adds icons to the preset modes, such that the slider in home assistant can be used. This is based on [this pull request from libdyson-wg/ha-dyson](https://github.com/libdyson-wg/ha-dyson/pull/319) as I did basically the same thing there.

Someone need to do the French translation as I don't speak French.

This of course breaks existing automations which change the preset as the variable has changed. But this is the only thing I found so far. Tested with Dyson Pure Humidify + Cool Gen 1.

This is one of my first contributions to a public project! So please feel free to comment if I should do something different or could improve something!