### PR TITLE
Updated cleaning cycle entities

### DIFF
--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -2799,7 +2799,7 @@ class DysonNextCleaningCycleSensor(DysonEntity, SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTime.HOURS
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_icon = "mdi:timer-outline"
+        self._attr_icon = "mdi:calendar-filter"
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -2871,7 +2871,7 @@ class DysonCleaningTimeRemainingSensor(DysonEntity, SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_icon = "mdi:timer"
+        self._attr_icon = "mdi:wrench-clock"
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/hass_dyson/translations/de.json
+++ b/custom_components/hass_dyson/translations/de.json
@@ -210,6 +210,12 @@
       },
       "dominant_pollutant": {
         "name": "Dominierender Schadstoff"
+      },
+      "next_cleaning_cycle": {
+        "name": "Nächster Reinigungszyklus"
+      },
+      "cleaning_time_remaining": {
+        "name": "Verbleibende Reinigungszeit"
       }
     },
     "switch": {

--- a/custom_components/hass_dyson/translations/en.json
+++ b/custom_components/hass_dyson/translations/en.json
@@ -210,6 +210,12 @@
       },
       "dominant_pollutant": {
         "name": "Dominant Pollutant"
+      },
+      "next_cleaning_cycle": {
+        "name": "Next cleaning cycle"
+      },
+      "cleaning_time_remaining": {
+        "name": "Cleaning time remaining"
       }
     },
     "switch": {

--- a/custom_components/hass_dyson/translations/fr.json
+++ b/custom_components/hass_dyson/translations/fr.json
@@ -210,6 +210,12 @@
       },
       "dominant_pollutant": {
         "name": "Polluant dominant"
+      },
+      "next_cleaning_cycle": {
+        "name": "Prochain cycle de nettoyage"
+      },
+      "cleaning_time_remaining": {
+        "name": "Temps de nettoyage restant"
       }
     },
     "switch": {


### PR DESCRIPTION
This pull request just changes the naming and icons of NextCleaningCycle and CleaningTimeRemaining to make it easier to find, better integrated and prettier. It bothers me a bit that the entity name still is "_duration" and "_duration_2" but i haven't found a good solution yet.

Someone need to check the French translation as I don't speak French, but it should be fine.

This is one of my first contributions to a public project! So please feel free to comment if I should do something different or could improve something!