### PR TITLE
Feature/solarcycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![hacs][hacsbadge]][hacs]
 [![Codecov][codecov-shield]][codecov]
 
-A core-ready Home Assistant integration for Dyson air purifiers, heaters, humidifiers, fans, and robotic vacuums featuring real-time MQTT communication and complete platform coverage.
+A core-ready Home Assistant integration for Dyson air purifiers, heaters, humidifiers, fans, lights, and robotic vacuums featuring real-time MQTT communication, BLE proxy compatibility, and complete platform coverage.
 
 ## Current Features
 
@@ -59,15 +59,18 @@ A core-ready Home Assistant integration for Dyson air purifiers, heaters, humidi
 
 ## Planned Features
 
-Planned features are features we cannot currently complete due to lack of access to the
-device type.  If you feel you are technical enough to assist us with these features, we
-welcome the help.  If you feel you are not technical enough to assist, but can help
-financially, please consider a sponsorship.  Anything helps.  All sponsorship money goes
-directly to development devices for this integration.
+Planned features are features we cannot currently complete due to lack of access to device of that type.
+
+If you feel you are technical enough to assist us with these features, we welcome the help.  Please reply to the issue tied to the feature and we'll be happy to work with you on it.
+
+If you feel you are not technical enough to assist, but can help financially, please consider a sponsorship.
+
+Anything helps, and all sponsorship money goes directly to development devices for this integration.
 
 ### Vacuum Start
 
-- **Vacuum Start Controls** - Support the start in room functionality introduced in Home Assistant 2026.2.0 as well as "global" (all defined rooms)
+- **Vacuum Start Controls** - Support the start in room functionality introduced in
+Home Assistant 2026.2.0 as well as "global" (all defined rooms)
 
 ### BLE Devices
 
@@ -262,6 +265,7 @@ hass_dyson:
 - **[Device Management](docs/DEVICE_MANAGEMENT.md)** - Information on device discovery and configuration
 - **[Entities](docs/ENTITIES.md)** - Information on entities to expect for a given device type
 - **[Sensors](docs/SENSORS.md)** - Information on included sensors for devices
+- **[Lights](docs/LIGHTS.md)** - Information on Active BLE lights
 - **[Supported Devices](docs/SUPPORTED_DEVICES.md)** - Information on devices tested and known to be supported
 
 ### **Quick References**

--- a/README.md
+++ b/README.md
@@ -72,11 +72,6 @@ Anything helps, and all sponsorship money goes directly to development devices f
 - **Vacuum Start Controls** - Support the start in room functionality introduced in
 Home Assistant 2026.2.0 as well as "global" (all defined rooms)
 
-### BLE Devices
-
-- **Auto-discover for BLE devices** - BLE Lights may currently be added manually, and work best when paired with a cloud account
-  - We plan to expand this to prompt the user with the pairing flow when found
-
 ## Quick Start
 
 ### Installation

--- a/custom_components/hass_dyson/__init__.py
+++ b/custom_components/hass_dyson/__init__.py
@@ -272,6 +272,7 @@ async def _create_discovery_flow(
                 "name": device_name,
                 "product_type": device_info.get("product_type", "unknown"),
                 "category": device_info.get("category", "unknown"),
+                "connection_category": device_info.get("connection_category", ""),
                 "auth_token": entry.data.get("auth_token"),
                 "email": entry.data.get("email"),
                 "parent_entry_id": entry.entry_id,

--- a/custom_components/hass_dyson/__init__.py
+++ b/custom_components/hass_dyson/__init__.py
@@ -372,7 +372,12 @@ async def _handle_new_device(
     """Handle setup for a new device."""
     device_serial = device_info["serial_number"]
 
-    if auto_add_devices:
+    # BLE-only (lecOnly) devices cannot be auto-created as MQTT devices.
+    # They require the user to go through the BLE Light config flow for pairing,
+    # so always route them to the discovery flow regardless of auto_add_devices.
+    is_ble_only = device_info.get("connection_category", "") == "lecOnly"
+
+    if auto_add_devices and not is_ble_only:
         # Create individual config entry for this device
         from .device_utils import create_cloud_device_config
 
@@ -395,10 +400,17 @@ async def _handle_new_device(
             f"dyson_create_device_{device_serial}",
         )
     else:
-        _LOGGER.info(
-            "Device %s discovered but auto-add disabled - device will be available for manual setup",
-            device_serial,
-        )
+        if is_ble_only:
+            _LOGGER.info(
+                "Device %s is a BLE-only (lecOnly) device — routing to discovery flow "
+                "for BLE Light manual pairing",
+                device_serial,
+            )
+        else:
+            _LOGGER.info(
+                "Device %s discovered but auto-add disabled - device will be available for manual setup",
+                device_serial,
+            )
         # Create discovery flow for manual device confirmation
         hass.async_create_background_task(
             _create_discovery_flow(hass, entry, device_info),

--- a/custom_components/hass_dyson/config_flow.py
+++ b/custom_components/hass_dyson/config_flow.py
@@ -967,6 +967,51 @@ class DysonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         default_serial = self._ble_serial or ""
         default_mac = self._ble_mac or ""
+
+        # If we know the serial but not the MAC, try to resolve it from the HA
+        # Bluetooth cache.  Dyson BLE devices advertise their serial number as
+        # the BLE device name (e.g. "CD06-GB-ABC1234A"), so a name match is
+        # sufficient.  We search all discovered service infos — not only those
+        # advertising the Dyson service UUID — because the device may not be in
+        # pairing mode and still be visible as a connectable advertisement.
+        if default_serial and not default_mac:
+            try:
+                from homeassistant.components import bluetooth as _bt
+
+                for si in _bt.async_discovered_service_info(
+                    self.hass, connectable=True
+                ):
+                    adv_name = (si.name or "").upper()
+                    if adv_name == default_serial.upper():
+                        default_mac = si.address
+                        self._ble_mac = default_mac
+                        _LOGGER.info(
+                            "Auto-resolved MAC for BLE device %s from Bluetooth cache: %s",
+                            default_serial,
+                            default_mac,
+                        )
+                        break
+
+                # Fall back to non-connectable advertisements if not found above
+                if not default_mac:
+                    for si in _bt.async_discovered_service_info(
+                        self.hass, connectable=False
+                    ):
+                        adv_name = (si.name or "").upper()
+                        if adv_name == default_serial.upper():
+                            default_mac = si.address
+                            self._ble_mac = default_mac
+                            _LOGGER.info(
+                                "Auto-resolved MAC for BLE device %s from non-connectable cache: %s",
+                                default_serial,
+                                default_mac,
+                            )
+                            break
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Bluetooth MAC auto-resolve unavailable for %s", default_serial
+                )
+
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_SERIAL_NUMBER, default=default_serial): str,
@@ -1686,6 +1731,17 @@ class DysonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Update context with device name for discovery card subtitle
         self.context["title_placeholders"] = {"name": device_name}
+
+        # BLE-only (lecOnly) devices cannot be set up via the MQTT discovery path.
+        # Redirect to the BLE configure step so the user gets the correct pairing
+        # flow (MAC address entry + automatic LTK fetch) with serial pre-filled.
+        if discovery_info.get("connection_category") == "lecOnly":
+            _LOGGER.info(
+                "Device %s is BLE-only (lecOnly) — redirecting discovery to BLE configure flow",
+                device_serial,
+            )
+            self._ble_serial = device_serial
+            return await self.async_step_ble_configure()
 
         # Get better display name for device type
         from .const import AVAILABLE_DEVICE_CATEGORIES

--- a/custom_components/hass_dyson/config_flow.py
+++ b/custom_components/hass_dyson/config_flow.py
@@ -286,8 +286,12 @@ class DysonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         name = getattr(device, "name", "Unknown")
         try:
-            # BLE-only devices are supported (managed via BLE config entry)
-            if getattr(device, "connection_category", None) == "lecOnly":
+            # BLE-only devices are supported (managed via BLE config entry).
+            # connection_category may be a plain string or a ConnectionCategory enum
+            # from libdyson_rest — normalise to string value before comparing.
+            connection_cat = getattr(device, "connection_category", None)
+            connection_cat_val = getattr(connection_cat, "value", connection_cat)
+            if connection_cat_val == "lecOnly":
                 _LOGGER.debug(
                     "Device %s is a BLE-only device (lecOnly) — supported", name
                 )
@@ -1573,11 +1577,16 @@ class DysonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         device_list: list[dict[str, Any]] = []
         if self._discovered_devices is not None:
             for device in self._discovered_devices:
+                # Normalise connection_category: may be a ConnectionCategory enum
+                # or a plain string — store the string value for later use.
+                conn_cat = getattr(device, "connection_category", None)
+                conn_cat_val = getattr(conn_cat, "value", conn_cat) or ""
                 device_info = {
                     "serial_number": device.serial_number,
                     "name": getattr(device, "name", f"Dyson {device.serial_number}"),
                     "product_type": getattr(device, "product_type", "unknown"),
                     "category": getattr(device, "category", "unknown"),
+                    "connection_category": conn_cat_val,
                 }
                 device_list.append(device_info)
 

--- a/custom_components/hass_dyson/coordinator.py
+++ b/custom_components/hass_dyson/coordinator.py
@@ -2358,11 +2358,16 @@ class DysonCloudAccountCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Build device info list from cloud devices."""
         updated_devices = []
         for device in devices:
+            # Normalise connection_category: may be a ConnectionCategory enum or
+            # a plain string — store the string value so downstream checks work.
+            conn_cat = getattr(device, "connection_category", None)
+            conn_cat_val = getattr(conn_cat, "value", conn_cat) or ""
             device_info = {
                 "serial_number": device.serial_number,
                 "name": getattr(device, "name", f"Dyson {device.serial_number}"),
                 "product_type": getattr(device, "product_type", "unknown"),
                 "category": getattr(device, "category", "unknown"),
+                "connection_category": conn_cat_val,
             }
             updated_devices.append(device_info)
         return updated_devices
@@ -2405,24 +2410,32 @@ class DysonCloudAccountCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if auto_add_devices:
             for device in devices:
                 if device.serial_number in new_devices:
-                    if getattr(device, "connection_category", None) == "lecOnly":
+                    # Normalise connection_category: may be enum or string
+                    conn_cat = getattr(device, "connection_category", None)
+                    conn_cat_val = getattr(conn_cat, "value", conn_cat)
+                    if conn_cat_val == "lecOnly":
                         _LOGGER.info(
                             "Skipping BLE-only device %s from auto-add (lecOnly) "
-                            "\u2014 set up via 'Dyson BLE Light' instead",
+                            "\u2014 will trigger BLE Light discovery flow instead",
                             device.serial_number,
                         )
+                        await self._create_ble_discovery_flow(device)
                         continue
                     await self._create_device_entry(device)
         else:
             # Create discovery flows for manual device addition
             for device in devices:
                 if device.serial_number in new_devices:
-                    if getattr(device, "connection_category", None) == "lecOnly":
+                    # Normalise connection_category: may be enum or string
+                    conn_cat = getattr(device, "connection_category", None)
+                    conn_cat_val = getattr(conn_cat, "value", conn_cat)
+                    if conn_cat_val == "lecOnly":
                         _LOGGER.info(
                             "Skipping BLE-only device %s from discovery (lecOnly) "
-                            "\u2014 set up via 'Dyson BLE Light' instead",
+                            "\u2014 will trigger BLE Light discovery flow instead",
                             device.serial_number,
                         )
+                        await self._create_ble_discovery_flow(device)
                         continue
                     await self._create_discovery_flow(device)
             _LOGGER.info(
@@ -2532,6 +2545,12 @@ class DysonCloudAccountCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "name": device_name,
                         "product_type": getattr(device, "product_type", "unknown"),
                         "category": getattr(device, "category", "unknown"),
+                        "connection_category": getattr(
+                            getattr(device, "connection_category", None),
+                            "value",
+                            getattr(device, "connection_category", ""),
+                        )
+                        or "",
                         "auth_token": self._auth_token,
                         "email": self._email,
                         "parent_entry_id": self.config_entry.entry_id,
@@ -2543,6 +2562,78 @@ class DysonCloudAccountCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
         except Exception as e:
             _LOGGER.error("Failed to create discovery flow for %s: %s", device_name, e)
+
+    async def _create_ble_discovery_flow(self, device) -> None:
+        """Create a discovery flow that routes the user to the BLE Light setup.
+
+        For lecOnly (BLE-only) devices discovered via cloud polling, we cannot
+        auto-create an entry because BLE pairing requires a MAC address and LTK.
+        Instead, trigger a discovery notification that, when clicked, routes the
+        user directly to the BLE configure step (with serial pre-filled).
+        """
+        device_serial = device.serial_number
+        device_name = getattr(device, "name", f"Dyson {device_serial}")
+
+        # Skip if already set up (BLE or any other entry)
+        existing_entries = [
+            entry
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
+            if (
+                entry.data.get(CONF_SERIAL_NUMBER) == device_serial
+                and entry.entry_id != self.config_entry.entry_id
+            )
+        ]
+        if existing_entries:
+            _LOGGER.debug(
+                "BLE device %s already has a config entry, skipping", device_serial
+            )
+            return
+
+        # Skip if a BLE discovery flow is already in progress for this device
+        existing_flows = [
+            flow
+            for flow in self.hass.config_entries.flow.async_progress()
+            if (
+                flow["handler"] == DOMAIN
+                and flow.get("context", {}).get("unique_id") == device_serial
+            )
+        ]
+        if existing_flows:
+            _LOGGER.debug(
+                "Discovery flow already in progress for BLE device %s", device_serial
+            )
+            return
+
+        _LOGGER.info(
+            "Creating BLE discovery flow for lecOnly device: %s (%s)",
+            device_name,
+            device_serial,
+        )
+        try:
+            result = await self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={
+                        "source": "discovery",
+                        "unique_id": device_serial,
+                    },
+                    data={
+                        "serial_number": device_serial,
+                        "name": device_name,
+                        "product_type": getattr(device, "product_type", "unknown"),
+                        "category": getattr(device, "category", "unknown"),
+                        "connection_category": "lecOnly",
+                        "auth_token": self._auth_token,
+                        "email": self._email,
+                        "parent_entry_id": self.config_entry.entry_id,
+                    },
+                )
+            )
+            _LOGGER.info("BLE discovery flow created for %s: %s", device_name, result)
+        except Exception as e:
+            _LOGGER.error(
+                "Failed to create BLE discovery flow for %s: %s", device_name, e
+            )
 
 
 class DysonBLEDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "libdyson-rest==0.12.1"
   ],
-  "version": "0.33.0-beta.17"
+  "version": "0.33.0-beta.18"
 }

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "libdyson-rest==0.12.1"
   ],
-  "version": "0.33.0-beta.18"
+  "version": "0.33.0-beta.19"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-dyson"
-version = "0.33.0-beta.17"
+version = "0.33.0-beta.18"
 description = "Home Assistant Dyson integration focusing on device capabilities and connection information"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-dyson"
-version = "0.33.0-beta.18"
+version = "0.33.0-beta.19"
 description = "Home Assistant Dyson integration focusing on device capabilities and connection information"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_config_flow_consolidated.py
+++ b/tests/test_config_flow_consolidated.py
@@ -528,13 +528,13 @@ class TestDysonConfigFlowConnectivityTypeFiltering:
         connected_config.mqtt = mqtt_obj
         standard_device.connected_configuration = connected_config
 
-        # Mock device without MQTT credentials (unsupported)
+        # Mock BLE-only device (lecOnly) — supported via BLE path, not MQTT
         lec_only_device = MagicMock()
         lec_only_device.name = "LEC Only Device"
         lec_only_device.connection_category = "lecOnly"
         lec_only_device.serial_number = "LEC456"
         lec_only_device.product_type = "999"
-        # No connected_configuration
+        # No connected_configuration — BLE-only devices don't have MQTT
         lec_only_device.connected_configuration = None
 
         config_flow_with_client._cloud_client.get_devices.return_value = [
@@ -549,8 +549,8 @@ class TestDysonConfigFlowConnectivityTypeFiltering:
         # The flow proceeds to cloud_preferences after filtering devices
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "cloud_preferences"
-        # The device count should reflect filtering (1 supported device)
-        assert result["description_placeholders"]["device_count"] == "1"
+        # Both the MQTT device and the lecOnly BLE device are supported — device_count is 2
+        assert result["description_placeholders"]["device_count"] == "2"
 
     @pytest.mark.asyncio
     async def test_supported_connectivity_type_inclusion(self, config_flow_with_client):
@@ -615,8 +615,9 @@ class TestDysonConfigFlowConnectivityTypeFiltering:
             # Supported devices (with MQTT)
             create_device_with_mqtt("Device 1", "D1", "475", None),
             create_device_with_mqtt("Device 2", "D2", "527", "standard"),
-            # Unsupported devices (no MQTT)
+            # Supported via BLE path (lecOnly) — no MQTT but still supported
             create_device_without_mqtt("Device 3", "D3", "999", "lecOnly"),
+            # Truly unsupported — no MQTT and no lecOnly connection_category
             create_device_without_mqtt("Device 4", "D4", "888", None),
         ]
 
@@ -629,16 +630,23 @@ class TestDysonConfigFlowConnectivityTypeFiltering:
         # Should proceed to cloud_preferences after filtering
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "cloud_preferences"
-        # Should show 2 supported devices (only those with MQTT credentials)
-        assert result["description_placeholders"]["device_count"] == "2"
+        # 3 supported: D1 (MQTT), D2 (MQTT), D3 (lecOnly BLE); D4 filtered out
+        assert result["description_placeholders"]["device_count"] == "3"
 
     @pytest.mark.asyncio
     async def test_no_supported_devices_available(self, config_flow_with_client):
-        """Test behavior when no devices with MQTT credentials are available."""
-        # Mock device without MQTT credentials
+        """Test behavior when no supported devices are found on the account.
+
+        A device is unsupported if it has neither MQTT credentials nor a
+        lecOnly connection_category (e.g. a cloud-only device with no local
+        connectivity — connection_category is None and no MQTT config).
+        """
+        # Mock a device that is truly unsupported:
+        # - no connection_category (not lecOnly)
+        # - no MQTT connected_configuration
         unsupported_device = MagicMock()
         unsupported_device.name = "Unsupported Device"
-        unsupported_device.connection_category = "lecOnly"
+        unsupported_device.connection_category = None  # not lecOnly
         unsupported_device.serial_number = "UNS123"
         unsupported_device.product_type = "999"
         unsupported_device.connected_configuration = None
@@ -655,6 +663,85 @@ class TestDysonConfigFlowConnectivityTypeFiltering:
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "cloud_preferences"
         assert result["description_placeholders"]["device_count"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_lec_only_account_succeeds(self, config_flow_with_client):
+        """Test that a cloud account containing only lecOnly BLE devices can be added.
+
+        Reproduces the bug reported in issue #175 where accounts with no MQTT
+        devices caused cloud account creation to fail with 'no_supported_devices'.
+        lecOnly devices are supported via the BLE Light config flow and must be
+        accepted here so the account entry can be created.
+        """
+        lec_device_1 = MagicMock()
+        lec_device_1.name = "Dyson Lightcycle Morph"
+        lec_device_1.connection_category = "lecOnly"
+        lec_device_1.serial_number = "CD06-GB-ABC1234A"
+        lec_device_1.product_type = "CD06"
+        lec_device_1.connected_configuration = None  # No MQTT — BLE-only
+
+        lec_device_2 = MagicMock()
+        lec_device_2.name = "Dyson Lightcycle Morph Desk"
+        lec_device_2.connection_category = "lecOnly"
+        lec_device_2.serial_number = "CF06-GB-XYZ5678B"
+        lec_device_2.product_type = "CF06"
+        lec_device_2.connected_configuration = None
+
+        config_flow_with_client._cloud_client.get_devices.return_value = [
+            lec_device_1,
+            lec_device_2,
+        ]
+
+        user_input = {"connection_type": "local_cloud_fallback"}
+
+        result = await config_flow_with_client.async_step_connection(user_input)
+
+        # Account with only lecOnly devices must NOT be rejected with no_supported_devices.
+        # It should proceed to cloud_preferences with both devices counted.
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "cloud_preferences"
+        assert result["description_placeholders"]["device_count"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_lec_only_enum_connection_category(self, config_flow_with_client):
+        """Test that lecOnly is recognised even when connection_category is an enum.
+
+        libdyson_rest may return a ConnectionCategory enum rather than a plain
+        string.  The integration must normalise it via .value before comparing.
+        """
+
+        class FakeConnectionCategory:
+            """Minimal stand-in for libdyson_rest ConnectionCategory enum."""
+
+            LEC_ONLY = None  # will be set below
+
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+            def __eq__(self, other):
+                if isinstance(other, FakeConnectionCategory):
+                    return self.value == other.value
+                return self.value == other
+
+        lec_enum = FakeConnectionCategory("lecOnly")
+
+        lec_device = MagicMock()
+        lec_device.name = "Dyson Lightcycle Morph"
+        lec_device.connection_category = lec_enum  # enum, not a plain string
+        lec_device.serial_number = "CD06-GB-ABC1234A"
+        lec_device.product_type = "CD06"
+        lec_device.connected_configuration = None
+
+        config_flow_with_client._cloud_client.get_devices.return_value = [lec_device]
+
+        user_input = {"connection_type": "local_cloud_fallback"}
+
+        result = await config_flow_with_client.async_step_connection(user_input)
+
+        # The enum value must be unwrapped — device should be accepted
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "cloud_preferences"
+        assert result["description_placeholders"]["device_count"] == "1"
 
     @pytest.mark.asyncio
     async def test_flrc_device_without_mqtt_filtered(self, config_flow_with_client):

--- a/tests/test_select_coverage_boost.py
+++ b/tests/test_select_coverage_boost.py
@@ -1,0 +1,849 @@
+"""Coverage boost tests for select.py targeting specific uncovered branches.
+
+Covers:
+- Robot power select entity setup in async_setup_entry (VisNav, Heurist, 360 Eye, Generic)
+- DysonFanControlModeSelect local_only connection type paths
+- DysonFanControlModeSelect async_select_option Sleep mode
+- DysonOscillationModeSelect midpoint save/restore transitions
+- DysonWaterHardnessSelect update and option selection methods
+- Robot power select entity _handle_coordinator_update and async_select_option
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from custom_components.hass_dyson.const import (
+    CONF_HOSTNAME,
+    DOMAIN,
+    ROBOT_POWER_OPTIONS_360_EYE,
+    ROBOT_POWER_OPTIONS_HEURIST,
+    ROBOT_POWER_OPTIONS_VIS_NAV,
+)
+from custom_components.hass_dyson.select import (
+    DysonFanControlModeSelect,
+    DysonOscillationModeSelect,
+    DysonRobotPower360EyeSelect,
+    DysonRobotPowerGenericSelect,
+    DysonRobotPowerHeuristSelect,
+    DysonRobotPowerVisNavSelect,
+    DysonWaterHardnessSelect,
+    async_setup_entry,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock coordinator with all required attributes."""
+    coordinator = Mock()
+    coordinator.serial_number = "NK6-EU-MHA0000A"
+    coordinator.device_name = "Test Device"
+    coordinator.device = Mock()
+    coordinator.device_capabilities = []
+    coordinator.device_category = []
+    coordinator.device.get_state_value = Mock(return_value="OFF")
+    coordinator.device.auto_mode = False
+    coordinator.device.set_auto_mode = AsyncMock()
+    coordinator.device.set_night_mode = AsyncMock()
+    coordinator.device.set_water_hardness = AsyncMock()
+    coordinator.device.set_robot_power = AsyncMock()
+    coordinator.device.set_oscillation_preset = AsyncMock()
+    coordinator.device.set_oscillation_angles = AsyncMock()
+    coordinator.device.set_oscillation_breeze = AsyncMock()
+    coordinator.device._state_data = {"product-state": {}}
+    coordinator.data = {
+        "product-state": {
+            "auto": "OFF",
+            "nmod": "OFF",
+            "oson": "OFF",
+            "osal": "0000",
+            "osau": "0350",
+            "ancp": "0175",
+            "wath": "1350",
+        }
+    }
+    coordinator.config_entry = Mock()
+    coordinator.config_entry.data = {
+        CONF_HOSTNAME: "192.168.1.100",
+        "connection_type": "cloud",
+    }
+    coordinator.config_entry.unique_id = "NK6-EU-MHA0000A"
+    coordinator.config_entry.entry_id = "NK6-EU-MHA0000A"
+    return coordinator
+
+
+@pytest.fixture
+def mock_hass(mock_coordinator):
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.data = {DOMAIN: {"NK6-EU-MHA0000A": mock_coordinator}}
+    return hass
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Create a mock config entry."""
+    entry = Mock()
+    entry.data = {CONF_HOSTNAME: "192.168.1.100", "connection_type": "cloud"}
+    entry.unique_id = "NK6-EU-MHA0000A"
+    entry.entry_id = "NK6-EU-MHA0000A"
+    return entry
+
+
+# ===== Robot power entity setup tests =====
+
+
+class TestRobotPowerSetup:
+    """Test robot power select setup in async_setup_entry."""
+
+    @pytest.mark.asyncio
+    async def test_setup_vis_nav_robot(self, mock_hass, mock_config_entry):
+        """Test setup creates VisNav select for Mapping+DirectedCleaning capabilities."""
+        coordinator = mock_hass.data[DOMAIN]["NK6-EU-MHA0000A"]
+        coordinator.device_capabilities = ["Mapping", "DirectedCleaning"]
+        coordinator.device_category = ["robot"]
+
+        mock_add_entities = MagicMock()
+        await async_setup_entry(mock_hass, mock_config_entry, mock_add_entities)
+
+        entities = mock_add_entities.call_args[0][0]
+        entity_types = [type(e).__name__ for e in entities]
+        assert "DysonRobotPowerVisNavSelect" in entity_types
+        # VisNav only - not 360 Eye or Generic
+        assert "DysonRobotPower360EyeSelect" not in entity_types
+        assert "DysonRobotPowerGenericSelect" not in entity_types
+
+    @pytest.mark.asyncio
+    async def test_setup_heurist_robot(self, mock_hass, mock_config_entry):
+        """Test setup creates Heurist select for Heat capability."""
+        coordinator = mock_hass.data[DOMAIN]["NK6-EU-MHA0000A"]
+        coordinator.device_capabilities = ["Heat"]
+        coordinator.device_category = ["robot"]
+
+        mock_add_entities = MagicMock()
+        await async_setup_entry(mock_hass, mock_config_entry, mock_add_entities)
+
+        entities = mock_add_entities.call_args[0][0]
+        entity_types = [type(e).__name__ for e in entities]
+        assert "DysonRobotPowerHeuristSelect" in entity_types
+        assert "DysonRobotPowerVisNavSelect" not in entity_types
+        assert "DysonRobotPower360EyeSelect" not in entity_types
+
+    @pytest.mark.asyncio
+    async def test_setup_360_eye_and_generic_robot(self, mock_hass, mock_config_entry):
+        """Test setup creates 360Eye + Generic selects for unknown robot capabilities."""
+        coordinator = mock_hass.data[DOMAIN]["NK6-EU-MHA0000A"]
+        coordinator.device_capabilities = []  # No special capabilities
+        coordinator.device_category = ["robot"]
+
+        mock_add_entities = MagicMock()
+        await async_setup_entry(mock_hass, mock_config_entry, mock_add_entities)
+
+        entities = mock_add_entities.call_args[0][0]
+        entity_types = [type(e).__name__ for e in entities]
+        assert "DysonRobotPower360EyeSelect" in entity_types
+        assert "DysonRobotPowerGenericSelect" in entity_types
+        assert "DysonRobotPowerVisNavSelect" not in entity_types
+        assert "DysonRobotPowerHeuristSelect" not in entity_types
+
+
+# ===== DysonFanControlModeSelect tests =====
+
+
+class TestFanControlModeSelectLocalOnly:
+    """Test DysonFanControlModeSelect local_only connection type paths."""
+
+    def test_initialization_local_only_options(self, mock_coordinator):
+        """Test local_only devices show only Auto and Manual options."""
+        mock_coordinator.config_entry.data = {"connection_type": "local_only"}
+        entity = DysonFanControlModeSelect(mock_coordinator)
+
+        assert entity._attr_options == ["Auto", "Manual"]
+        assert "Sleep" not in entity._attr_options
+
+    def test_handle_update_local_only_auto(self, mock_coordinator):
+        """Test coordinator update sets Auto for local_only device in auto mode."""
+        mock_coordinator.config_entry.data = {"connection_type": "local_only"}
+        mock_coordinator.device.auto_mode = True
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Auto"
+
+    def test_handle_update_local_only_manual(self, mock_coordinator):
+        """Test coordinator update sets Manual for local_only device not in auto mode."""
+        mock_coordinator.config_entry.data = {"connection_type": "local_only"}
+        mock_coordinator.device.auto_mode = False
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Manual"
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update when device is None sets option to None."""
+        mock_coordinator.config_entry.data = {"connection_type": "local_only"}
+        mock_coordinator.device = None
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_sleep_calls_night_mode(self, mock_coordinator):
+        """Test selecting Sleep calls set_night_mode and set_auto_mode(False)."""
+        mock_coordinator.config_entry.data = {"connection_type": "cloud"}
+        mock_coordinator.device.set_night_mode = AsyncMock()
+        mock_coordinator.device.set_auto_mode = AsyncMock()
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        await entity.async_select_option("Sleep")
+
+        mock_coordinator.device.set_night_mode.assert_called_once_with(True)
+        mock_coordinator.device.set_auto_mode.assert_called_once_with(False)
+
+    @pytest.mark.asyncio
+    async def test_select_option_sleep_connection_error(self, mock_coordinator):
+        """Test Sleep option handles ConnectionError gracefully."""
+        mock_coordinator.config_entry.data = {"connection_type": "cloud"}
+        mock_coordinator.device.set_night_mode = AsyncMock(
+            side_effect=ConnectionError("Network error")
+        )
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        # Should not raise
+        await entity.async_select_option("Sleep")
+
+    @pytest.mark.asyncio
+    async def test_select_option_sleep_value_error(self, mock_coordinator):
+        """Test Sleep option handles ValueError gracefully."""
+        mock_coordinator.config_entry.data = {"connection_type": "cloud"}
+        mock_coordinator.device.set_night_mode = AsyncMock(
+            side_effect=ValueError("Bad value")
+        )
+
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        # Should not raise
+        await entity.async_select_option("Sleep")
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test selecting option when device is None returns early."""
+        mock_coordinator.device = None
+        entity = DysonFanControlModeSelect(mock_coordinator)
+        # Should return without error
+        await entity.async_select_option("Auto")
+
+
+# ===== DysonOscillationModeSelect midpoint transition tests =====
+
+
+class TestOscillationMidpointTransitions:
+    """Test oscillation mode midpoint save/restore during mode transitions."""
+
+    def test_midpoint_saved_on_transition_to_350(self, mock_coordinator):
+        """Test midpoint saved when transitioning from non-350 to 350 mode."""
+        mock_coordinator.device_capabilities = []
+        mock_coordinator.device.get_state_value = Mock(
+            side_effect=lambda ps, key, default: {
+                "ancp": "0350",
+                "osal": "0000",
+                "osau": "0350",
+                "oson": "ON",
+            }.get(key, default)
+        )
+
+        entity = DysonOscillationModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._last_known_mode = "90°"
+        entity._saved_sweep_midpoint = None
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        # Should have saved midpoint (0+350)//2 = 175
+        assert entity._saved_sweep_midpoint == 175
+        assert entity._last_known_mode == "350°"
+
+    def test_midpoint_cleared_on_transition_from_350(self, mock_coordinator):
+        """Test midpoint discarded when transitioning from 350 to non-350 mode."""
+        mock_coordinator.device_capabilities = []
+        mock_coordinator.device.get_state_value = Mock(
+            side_effect=lambda ps, key, default: {
+                "ancp": "0090",
+                "osal": "0045",
+                "osau": "0135",
+                "oson": "ON",
+            }.get(key, default)
+        )
+
+        entity = DysonOscillationModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._last_known_mode = "350°"
+        entity._saved_sweep_midpoint = 175  # Previously saved
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        # Midpoint should be cleared since device left 350° mode externally
+        assert entity._saved_sweep_midpoint is None
+        assert entity._last_known_mode == "90°"
+
+    def test_no_midpoint_save_when_already_350(self, mock_coordinator):
+        """Test midpoint NOT saved when device stays in 350 mode."""
+        mock_coordinator.device_capabilities = []
+        mock_coordinator.device.get_state_value = Mock(
+            side_effect=lambda ps, key, default: {
+                "ancp": "0350",
+                "osal": "0000",
+                "osau": "0350",
+            }.get(key, default)
+        )
+
+        entity = DysonOscillationModeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._last_known_mode = "350°"  # Already in 350°
+        entity._saved_sweep_midpoint = None
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        # Midpoint should NOT be saved (already was in 350°)
+        assert entity._saved_sweep_midpoint is None
+
+
+# ===== DysonWaterHardnessSelect tests =====
+
+
+class TestWaterHardnessSelect:
+    """Test DysonWaterHardnessSelect entity."""
+
+    def test_handle_update_soft(self, mock_coordinator):
+        """Test coordinator update with Soft (2025) water hardness."""
+        mock_coordinator.device.get_state_value = Mock(return_value="2025")
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Soft"
+
+    def test_handle_update_medium(self, mock_coordinator):
+        """Test coordinator update with Medium (1350) water hardness."""
+        mock_coordinator.device.get_state_value = Mock(return_value="1350")
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Medium"
+
+    def test_handle_update_hard(self, mock_coordinator):
+        """Test coordinator update with Hard (0675) water hardness."""
+        mock_coordinator.device.get_state_value = Mock(return_value="0675")
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Hard"
+
+    def test_handle_update_unknown_defaults_medium(self, mock_coordinator):
+        """Test coordinator update with unknown value defaults to Medium."""
+        mock_coordinator.device.get_state_value = Mock(return_value="9999")
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == "Medium"
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update with no device sets None."""
+        mock_coordinator.device = None
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity._handle_coordinator_update"
+        ):
+            entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_soft(self, mock_coordinator):
+        """Test selecting Soft water hardness calls set_water_hardness."""
+        mock_coordinator.device.set_water_hardness = AsyncMock()
+        mock_coordinator.device.async_write_ha_state = MagicMock()
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("Soft")
+
+        mock_coordinator.device.set_water_hardness.assert_called_once_with("soft")
+        assert entity._attr_current_option == "Soft"
+
+    @pytest.mark.asyncio
+    async def test_select_option_hard(self, mock_coordinator):
+        """Test selecting Hard water hardness calls set_water_hardness."""
+        mock_coordinator.device.set_water_hardness = AsyncMock()
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("Hard")
+
+        mock_coordinator.device.set_water_hardness.assert_called_once_with("hard")
+
+    @pytest.mark.asyncio
+    async def test_select_option_invalid(self, mock_coordinator):
+        """Test selecting invalid option returns without calling device."""
+        mock_coordinator.device.set_water_hardness = AsyncMock()
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        await entity.async_select_option("VeryHard")
+
+        mock_coordinator.device.set_water_hardness.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_select_option_connection_error(self, mock_coordinator):
+        """Test water hardness option handles ConnectionError gracefully."""
+        mock_coordinator.device.set_water_hardness = AsyncMock(
+            side_effect=ConnectionError("Network error")
+        )
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        # Should not raise
+        await entity.async_select_option("Medium")
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test water hardness option returns early when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        # Should not raise
+        await entity.async_select_option("Soft")
+
+    def test_extra_state_attributes(self, mock_coordinator):
+        """Test extra_state_attributes returns water hardness data."""
+        mock_coordinator.device.get_state_value = Mock(return_value="1350")
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        entity._attr_current_option = "Medium"
+
+        attrs = entity.extra_state_attributes
+        assert attrs is not None
+        assert "water_hardness" in attrs
+        assert "water_hardness_raw" in attrs
+
+    def test_extra_state_attributes_no_device(self, mock_coordinator):
+        """Test extra_state_attributes returns None when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonWaterHardnessSelect(mock_coordinator)
+        assert entity.extra_state_attributes is None
+
+
+# ===== Robot power select entity tests =====
+
+
+class TestRobotPower360EyeSelect:
+    """Test DysonRobotPower360EyeSelect entity."""
+
+    def test_initialization(self, mock_coordinator):
+        """Test 360 Eye select initialization."""
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+
+        assert "_robot_power_360_eye" in entity._attr_unique_id
+        assert entity._attr_options == list(ROBOT_POWER_OPTIONS_360_EYE.values())
+
+    def test_handle_update_with_power_level(self, mock_coordinator):
+        """Test coordinator update with known power level."""
+        # Get first key from options dict
+        first_key = list(ROBOT_POWER_OPTIONS_360_EYE.keys())[0]
+        first_val = ROBOT_POWER_OPTIONS_360_EYE[first_key]
+        mock_coordinator.device._state_data = {"product-state": {"fPwr": first_key}}
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == first_val
+
+    def test_handle_update_unknown_power_defaults_first(self, mock_coordinator):
+        """Test coordinator update with unknown power defaults to first option."""
+        mock_coordinator.device._state_data = {
+            "product-state": {"fPwr": "UNKNOWN_LEVEL"}
+        }
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert (
+            entity._attr_current_option == list(ROBOT_POWER_OPTIONS_360_EYE.values())[0]
+        )
+
+    def test_handle_update_no_fPwr_defaults_first(self, mock_coordinator):
+        """Test coordinator update with no fPwr key defaults to first option."""
+        mock_coordinator.device._state_data = {"product-state": {}}
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert (
+            entity._attr_current_option == list(ROBOT_POWER_OPTIONS_360_EYE.values())[0]
+        )
+
+    def test_handle_update_attribute_error_defaults_first(self, mock_coordinator):
+        """Test coordinator update with AttributeError defaults to first option."""
+        mock_coordinator.device._state_data = None  # Will cause AttributeError
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert (
+            entity._attr_current_option == list(ROBOT_POWER_OPTIONS_360_EYE.values())[0]
+        )
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update sets None when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_valid(self, mock_coordinator):
+        """Test selecting a valid power option calls set_robot_power."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        first_val = list(ROBOT_POWER_OPTIONS_360_EYE.values())[0]
+        first_key = list(ROBOT_POWER_OPTIONS_360_EYE.keys())[0]
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        await entity.async_select_option(first_val)
+
+        mock_coordinator.device.set_robot_power.assert_called_once_with(
+            first_key, "360eye"
+        )
+
+    @pytest.mark.asyncio
+    async def test_select_option_invalid(self, mock_coordinator):
+        """Test selecting an invalid power option skips device call."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        await entity.async_select_option("INVALID_OPTION")
+
+        mock_coordinator.device.set_robot_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test select option when device is None returns early."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        # Should not raise
+        await entity.async_select_option(list(ROBOT_POWER_OPTIONS_360_EYE.values())[0])
+
+    @pytest.mark.asyncio
+    async def test_select_option_exception(self, mock_coordinator):
+        """Test select option handles exceptions gracefully."""
+        mock_coordinator.device.set_robot_power = AsyncMock(
+            side_effect=Exception("Device error")
+        )
+
+        entity = DysonRobotPower360EyeSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        first_val = list(ROBOT_POWER_OPTIONS_360_EYE.values())[0]
+        # Should not raise
+        await entity.async_select_option(first_val)
+
+
+class TestRobotPowerGenericSelect:
+    """Test DysonRobotPowerGenericSelect entity."""
+
+    def test_initialization(self, mock_coordinator):
+        """Test Generic robot power select initialization."""
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+
+        assert "_robot_power_generic" in entity._attr_unique_id
+
+    def test_handle_update_with_power_level(self, mock_coordinator):
+        """Test coordinator update sets current option from state."""
+        first_key = list(ROBOT_POWER_OPTIONS_HEURIST.keys())[0]
+        first_val = ROBOT_POWER_OPTIONS_HEURIST[first_key]
+        mock_coordinator.device._state_data = {"product-state": {"fPwr": first_key}}
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        # Generic uses HEURIST options
+        assert entity._attr_current_option == first_val
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update sets None when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_valid(self, mock_coordinator):
+        """Test selecting a valid power option calls set_robot_power."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        first_val = list(ROBOT_POWER_OPTIONS_HEURIST.values())[0]
+        first_key = list(ROBOT_POWER_OPTIONS_HEURIST.keys())[0]
+
+        await entity.async_select_option(first_val)
+
+        mock_coordinator.device.set_robot_power.assert_called_once_with(
+            first_key, "generic"
+        )
+
+    @pytest.mark.asyncio
+    async def test_select_option_invalid_skips(self, mock_coordinator):
+        """Test invalid option skips device call."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        await entity.async_select_option("NONEXISTENT_OPTION")
+
+        mock_coordinator.device.set_robot_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test select option when device is None returns early."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        await entity.async_select_option(list(ROBOT_POWER_OPTIONS_HEURIST.values())[0])
+
+    @pytest.mark.asyncio
+    async def test_select_option_exception(self, mock_coordinator):
+        """Test select option handles exceptions gracefully."""
+        mock_coordinator.device.set_robot_power = AsyncMock(
+            side_effect=Exception("Failure")
+        )
+
+        entity = DysonRobotPowerGenericSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        first_val = list(ROBOT_POWER_OPTIONS_HEURIST.values())[0]
+        # Should not raise
+        await entity.async_select_option(first_val)
+
+
+class TestRobotPowerHeuristSelect:
+    """Test DysonRobotPowerHeuristSelect entity."""
+
+    def test_initialization(self, mock_coordinator):
+        """Test Heurist robot power select initialization."""
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+
+        assert "_robot_power_heurist" in entity._attr_unique_id
+        assert entity._attr_options == list(ROBOT_POWER_OPTIONS_HEURIST.values())
+
+    def test_handle_update_with_power_level(self, mock_coordinator):
+        """Test coordinator update sets current option from state."""
+        first_key = list(ROBOT_POWER_OPTIONS_HEURIST.keys())[0]
+        first_val = ROBOT_POWER_OPTIONS_HEURIST[first_key]
+        mock_coordinator.device._state_data = {"product-state": {"fPwr": first_key}}
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == first_val
+
+    def test_handle_update_unknown_power(self, mock_coordinator):
+        """Test coordinator update with unknown power defaults to first option."""
+        mock_coordinator.device._state_data = {"product-state": {"fPwr": "UNKNOWN"}}
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert (
+            entity._attr_current_option == list(ROBOT_POWER_OPTIONS_HEURIST.values())[0]
+        )
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update sets None when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_valid(self, mock_coordinator):
+        """Test selecting a valid power option calls set_robot_power."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        first_val = list(ROBOT_POWER_OPTIONS_HEURIST.values())[0]
+        first_key = list(ROBOT_POWER_OPTIONS_HEURIST.keys())[0]
+
+        await entity.async_select_option(first_val)
+
+        mock_coordinator.device.set_robot_power.assert_called_once_with(
+            first_key, "heurist"
+        )
+
+    @pytest.mark.asyncio
+    async def test_select_option_invalid_skips(self, mock_coordinator):
+        """Test invalid option skips device call."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        await entity.async_select_option("NONEXISTENT")
+
+        mock_coordinator.device.set_robot_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test select option when device is None returns early."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerHeuristSelect(mock_coordinator)
+        await entity.async_select_option(list(ROBOT_POWER_OPTIONS_HEURIST.values())[0])
+
+
+class TestRobotPowerVisNavSelect:
+    """Test DysonRobotPowerVisNavSelect entity."""
+
+    def test_initialization(self, mock_coordinator):
+        """Test Vis Nav robot power select initialization."""
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+
+        assert "_robot_power_vis_nav" in entity._attr_unique_id
+        assert entity._attr_options == list(ROBOT_POWER_OPTIONS_VIS_NAV.values())
+
+    def test_handle_update_with_power_level(self, mock_coordinator):
+        """Test coordinator update sets current option from state."""
+        first_key = list(ROBOT_POWER_OPTIONS_VIS_NAV.keys())[0]
+        first_val = ROBOT_POWER_OPTIONS_VIS_NAV[first_key]
+        mock_coordinator.device._state_data = {"product-state": {"fPwr": first_key}}
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option == first_val
+
+    def test_handle_update_no_device(self, mock_coordinator):
+        """Test coordinator update sets None when no device."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        entity._handle_coordinator_update()
+
+        assert entity._attr_current_option is None
+
+    @pytest.mark.asyncio
+    async def test_select_option_valid(self, mock_coordinator):
+        """Test selecting a valid power option calls set_robot_power."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        first_val = list(ROBOT_POWER_OPTIONS_VIS_NAV.values())[0]
+        first_key = list(ROBOT_POWER_OPTIONS_VIS_NAV.keys())[0]
+
+        await entity.async_select_option(first_val)
+
+        mock_coordinator.device.set_robot_power.assert_called_once_with(
+            first_key, "vis_nav"
+        )
+
+    @pytest.mark.asyncio
+    async def test_select_option_invalid_skips(self, mock_coordinator):
+        """Test invalid option skips device call."""
+        mock_coordinator.device.set_robot_power = AsyncMock()
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        await entity.async_select_option("NONEXISTENT")
+
+        mock_coordinator.device.set_robot_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_select_option_no_device(self, mock_coordinator):
+        """Test select option when device is None returns early."""
+        mock_coordinator.device = None
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        await entity.async_select_option(list(ROBOT_POWER_OPTIONS_VIS_NAV.values())[0])
+
+    @pytest.mark.asyncio
+    async def test_select_option_exception(self, mock_coordinator):
+        """Test select option handles exceptions gracefully."""
+        mock_coordinator.device.set_robot_power = AsyncMock(
+            side_effect=Exception("Device error")
+        )
+
+        entity = DysonRobotPowerVisNavSelect(mock_coordinator)
+        entity.async_write_ha_state = MagicMock()
+        first_val = list(ROBOT_POWER_OPTIONS_VIS_NAV.values())[0]
+        # Should not raise
+        await entity.async_select_option(first_val)

--- a/tests/test_services_coverage_boost.py
+++ b/tests/test_services_coverage_boost.py
@@ -1,0 +1,752 @@
+"""Coverage boost tests for services.py targeting specific uncovered branches.
+
+Covers:
+- _handle_set_sleep_timer error paths (ConnectionError, ValueError, AttributeError, Exception)
+- _handle_cancel_sleep_timer error paths (AttributeError, Exception)
+- _handle_set_oscillation_angles error paths (ConnectionError, ValueError, AttributeError)
+- _handle_get_cloud_devices with account_email filtering and exception handlers
+- _find_cloud_coordinators DysonDataUpdateCoordinator and config_entry fallback paths
+- async_handle_refresh_account_data with and without device_id
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from libdyson_rest import DysonAPIError, DysonAuthError, DysonConnectionError
+
+from custom_components.hass_dyson.const import (
+    CONF_DISCOVERY_METHOD,
+    DISCOVERY_CLOUD,
+    DOMAIN,
+)
+from custom_components.hass_dyson.services import (
+    _find_cloud_coordinators,
+    _handle_cancel_sleep_timer,
+    _handle_get_cloud_devices,
+    _handle_set_oscillation_angles,
+    _handle_set_sleep_timer,
+    async_handle_refresh_account_data,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a minimal mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {}}
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    return hass
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock device coordinator."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "VS6-EU-HJA1234A"
+    coordinator.device = MagicMock()
+    coordinator.device.set_sleep_timer = AsyncMock()
+    coordinator.device.set_oscillation_angles = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {
+        CONF_DISCOVERY_METHOD: DISCOVERY_CLOUD,
+        "email": "test@example.com",
+    }
+    coordinator.config_entry.entry_id = "test_entry_id"
+    return coordinator
+
+
+# ===== Sleep timer error handler tests =====
+
+
+class TestSleepTimerErrorHandlers:
+    """Test _handle_set_sleep_timer exception paths."""
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_connection_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on ConnectionError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=ConnectionError("Network unreachable")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 60}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_timeout_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on TimeoutError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=TimeoutError("Request timed out")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 30}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_value_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on ValueError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=ValueError("Invalid timer value")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 60}
+
+        with pytest.raises(HomeAssistantError, match="Invalid timer value"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_type_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on TypeError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=TypeError("Wrong type")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 60}
+
+        with pytest.raises(HomeAssistantError, match="Invalid timer value"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_attribute_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on AttributeError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=AttributeError("Method not available")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 60}
+
+        with pytest.raises(HomeAssistantError, match="Sleep timer not supported"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_set_sleep_timer_generic_exception(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test sleep timer raises HomeAssistantError on unexpected Exception."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=RuntimeError("Unexpected failure")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "minutes": 60}
+
+        with pytest.raises(HomeAssistantError, match="Failed to set sleep timer"):
+            await _handle_set_sleep_timer(mock_hass, call)
+
+
+# ===== Cancel sleep timer error handler tests =====
+
+
+class TestCancelSleepTimerErrorHandlers:
+    """Test _handle_cancel_sleep_timer exception paths."""
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_cancel_sleep_timer_connection_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test cancel sleep timer raises HomeAssistantError on ConnectionError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=ConnectionError("Network unreachable")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await _handle_cancel_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_cancel_sleep_timer_attribute_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test cancel sleep timer raises HomeAssistantError on AttributeError."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=AttributeError("Method not available")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        with pytest.raises(HomeAssistantError, match="Sleep timer not supported"):
+            await _handle_cancel_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_cancel_sleep_timer_generic_exception(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test cancel sleep timer raises HomeAssistantError on unexpected Exception."""
+        mock_coordinator.device.set_sleep_timer = AsyncMock(
+            side_effect=RuntimeError("Unexpected failure")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        with pytest.raises(HomeAssistantError, match="Failed to cancel sleep timer"):
+            await _handle_cancel_sleep_timer(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_cancel_sleep_timer_device_not_found(self, mock_get_coord, mock_hass):
+        """Test cancel sleep timer raises ServiceValidationError when device not found."""
+        mock_get_coord.return_value = None
+
+        call = MagicMock()
+        call.data = {"device_id": "nonexistent_device"}
+
+        with pytest.raises(ServiceValidationError, match="not found or not available"):
+            await _handle_cancel_sleep_timer(mock_hass, call)
+
+
+# ===== Oscillation angles error handler tests =====
+
+
+class TestOscillationAnglesErrorHandlers:
+    """Test _handle_set_oscillation_angles exception paths."""
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_oscillation_angles_connection_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test oscillation angles raises HomeAssistantError on ConnectionError."""
+        mock_coordinator.device.set_oscillation_angles = AsyncMock(
+            side_effect=ConnectionError("Network unreachable")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 45, "upper_angle": 135}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_oscillation_angles_timeout_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test oscillation angles raises HomeAssistantError on TimeoutError."""
+        mock_coordinator.device.set_oscillation_angles = AsyncMock(
+            side_effect=TimeoutError("Request timed out")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 45, "upper_angle": 135}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_oscillation_angles_value_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test oscillation angles raises HomeAssistantError on ValueError."""
+        mock_coordinator.device.set_oscillation_angles = AsyncMock(
+            side_effect=ValueError("Invalid angle")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 45, "upper_angle": 135}
+
+        with pytest.raises(HomeAssistantError, match="Invalid angle values"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_oscillation_angles_attribute_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test oscillation angles raises HomeAssistantError on AttributeError."""
+        mock_coordinator.device.set_oscillation_angles = AsyncMock(
+            side_effect=AttributeError("Method not available")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 45, "upper_angle": 135}
+
+        with pytest.raises(HomeAssistantError, match="not supported"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_oscillation_angles_generic_exception(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test oscillation angles raises HomeAssistantError on unexpected Exception."""
+        mock_coordinator.device.set_oscillation_angles = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 45, "upper_angle": 135}
+
+        with pytest.raises(HomeAssistantError, match="Failed to set oscillation"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+    @pytest.mark.asyncio
+    async def test_oscillation_angles_lower_exceeds_upper(self, mock_hass):
+        """Test oscillation angles raises ServiceValidationError when lower > upper."""
+        call = MagicMock()
+        call.data = {"device_id": "test_device", "lower_angle": 180, "upper_angle": 45}
+
+        with pytest.raises(ServiceValidationError, match="Lower angle must not exceed"):
+            await _handle_set_oscillation_angles(mock_hass, call)
+
+
+# ===== _handle_get_cloud_devices tests =====
+
+
+class TestGetCloudDevicesAccountEmail:
+    """Test _handle_get_cloud_devices with account_email filtering."""
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_account_email_found(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test account_email selects the correct coordinator."""
+        mock_find_coords.return_value = [
+            {"email": "first@example.com", "coordinator": MagicMock()},
+            {"email": "second@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.return_value = {
+            "devices": [],
+            "summary": {"total_devices": 0},
+        }
+
+        call = MagicMock()
+        call.data = {"account_email": "second@example.com", "sanitize": True}
+
+        result = await _handle_get_cloud_devices(mock_hass, call)
+
+        assert result["account_email"] == "second@example.com"
+        # Verify the second coordinator was selected
+        selected = mock_get_data.call_args[0][0]
+        assert selected["email"] == "second@example.com"
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    async def test_account_email_not_found_raises(self, mock_find_coords, mock_hass):
+        """Test account_email not found raises ServiceValidationError."""
+        mock_find_coords.return_value = [
+            {"email": "only@example.com", "coordinator": MagicMock()},
+        ]
+
+        call = MagicMock()
+        call.data = {"account_email": "nothere@example.com", "sanitize": False}
+
+        with pytest.raises(ServiceValidationError, match="not found"):
+            await _handle_get_cloud_devices(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_sanitize_true_excludes_summary(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test sanitize=True excludes the summary from response."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.return_value = {
+            "devices": [],
+            "summary": {"total_devices": 0, "source": "live_api"},
+        }
+
+        call = MagicMock()
+        call.data = {"sanitize": True}
+
+        result = await _handle_get_cloud_devices(mock_hass, call)
+
+        assert "summary" not in result
+        assert result["sanitized"] is True
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_sanitize_false_includes_summary(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test sanitize=False includes the summary in response."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.return_value = {
+            "devices": [],
+            "summary": {"total_devices": 0, "source": "live_api"},
+        }
+
+        call = MagicMock()
+        call.data = {"sanitize": False}
+
+        result = await _handle_get_cloud_devices(mock_hass, call)
+
+        assert "summary" in result
+        assert result["sanitized"] is False
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_dyson_auth_error_raises_ha_error(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test DysonAuthError from coordinator raises HomeAssistantError."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.side_effect = DysonAuthError("Auth failed")
+
+        call = MagicMock()
+        call.data = {"sanitize": False}
+
+        with pytest.raises(HomeAssistantError, match="Dyson service error"):
+            await _handle_get_cloud_devices(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_dyson_connection_error_raises_ha_error(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test DysonConnectionError from coordinator raises HomeAssistantError."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.side_effect = DysonConnectionError("Connection failed")
+
+        call = MagicMock()
+        call.data = {"sanitize": False}
+
+        with pytest.raises(HomeAssistantError, match="Dyson service error"):
+            await _handle_get_cloud_devices(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_dyson_api_error_raises_ha_error(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test DysonAPIError from coordinator raises HomeAssistantError."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.side_effect = DysonAPIError("API failed")
+
+        call = MagicMock()
+        call.data = {"sanitize": False}
+
+        with pytest.raises(HomeAssistantError, match="Dyson service error"):
+            await _handle_get_cloud_devices(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._find_cloud_coordinators")
+    @patch(
+        "custom_components.hass_dyson.services._get_cloud_device_data_from_coordinator"
+    )
+    async def test_unexpected_error_raises_ha_error(
+        self, mock_get_data, mock_find_coords, mock_hass
+    ):
+        """Test unexpected Exception from coordinator raises HomeAssistantError."""
+        mock_find_coords.return_value = [
+            {"email": "user@example.com", "coordinator": MagicMock()},
+        ]
+        mock_get_data.side_effect = RuntimeError("Unexpected failure")
+
+        call = MagicMock()
+        call.data = {"sanitize": False}
+
+        with pytest.raises(HomeAssistantError, match="Unexpected error"):
+            await _handle_get_cloud_devices(mock_hass, call)
+
+
+# ===== _find_cloud_coordinators tests =====
+
+
+class TestFindCloudCoordinators:
+    """Test _find_cloud_coordinators with various coordinator types."""
+
+    def test_find_data_update_coordinator_with_discovery_cloud(self, mock_hass):
+        """Test finding DysonDataUpdateCoordinator with DISCOVERY_CLOUD method."""
+        from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+        mock_coord = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coord.config_entry = MagicMock()
+        mock_coord.config_entry.data = {
+            CONF_DISCOVERY_METHOD: DISCOVERY_CLOUD,
+            "email": "user@example.com",
+        }
+        mock_coord.config_entry.entry_id = "test_entry"
+        mock_coord.device = MagicMock()  # Has device
+
+        mock_hass.data = {DOMAIN: {"test_key": mock_coord}}
+        mock_hass.config_entries.async_entries.return_value = []
+
+        result = _find_cloud_coordinators(mock_hass)
+
+        # Should find the DysonDataUpdateCoordinator with cloud discovery
+        emails = [c["email"] for c in result]
+        assert "user@example.com" in emails
+
+    def test_find_config_entry_fallback(self, mock_hass):
+        """Test fallback to config entries when no active coordinators found."""
+        # No data in hass.data
+        mock_hass.data = {DOMAIN: {}}
+
+        # But there's a config entry with devices
+        mock_entry = MagicMock()
+        mock_entry.data = {
+            "devices": [{"serial_number": "VS6-EU-HJA1234A"}],
+            "email": "fallback@example.com",
+            "auth_token": "token123",
+        }
+        mock_hass.config_entries.async_entries.return_value = [mock_entry]
+
+        result = _find_cloud_coordinators(mock_hass)
+
+        emails = [c["email"] for c in result]
+        assert "fallback@example.com" in emails
+        assert result[0]["type"] == "config_entry"
+        assert result[0]["coordinator"] is None  # No active coordinator
+
+    def test_config_entry_fallback_skips_no_email(self, mock_hass):
+        """Test config entry fallback skips entries without email."""
+        mock_hass.data = {DOMAIN: {}}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {
+            "devices": [{"serial_number": "VS6-EU-HJA1234A"}],
+            # No "email" key
+            "auth_token": "token123",
+        }
+        mock_hass.config_entries.async_entries.return_value = [mock_entry]
+
+        result = _find_cloud_coordinators(mock_hass)
+
+        assert result == []
+
+    def test_config_entry_fallback_skips_no_auth_token(self, mock_hass):
+        """Test config entry fallback skips entries without auth_token."""
+        mock_hass.data = {DOMAIN: {}}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {
+            "devices": [{"serial_number": "VS6-EU-HJA1234A"}],
+            "email": "user@example.com",
+            # No "auth_token" key
+        }
+        mock_hass.config_entries.async_entries.return_value = [mock_entry]
+
+        result = _find_cloud_coordinators(mock_hass)
+
+        assert result == []
+
+    def test_data_update_coordinator_no_device_skipped(self, mock_hass):
+        """Test DysonDataUpdateCoordinator without device is skipped."""
+        from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+        mock_coord = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coord.config_entry = MagicMock()
+        mock_coord.config_entry.data = {
+            CONF_DISCOVERY_METHOD: DISCOVERY_CLOUD,
+            "email": "user@example.com",
+        }
+        mock_coord.device = None  # No device
+
+        mock_hass.data = {DOMAIN: {"test_key": mock_coord}}
+        mock_hass.config_entries.async_entries.return_value = []
+
+        result = _find_cloud_coordinators(mock_hass)
+
+        # Should not find coordinator without device
+        emails = [c["email"] for c in result]
+        assert "user@example.com" not in emails
+
+
+# ===== async_handle_refresh_account_data tests =====
+
+
+class TestRefreshAccountData:
+    """Test async_handle_refresh_account_data with specific device and all devices."""
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_refresh_specific_device_success(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test refreshing a specific device by device_id."""
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        await async_handle_refresh_account_data(mock_hass, call)
+
+        mock_coordinator.async_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_refresh_specific_device_not_found(self, mock_get_coord, mock_hass):
+        """Test refreshing specific device that doesn't exist raises error."""
+        mock_get_coord.return_value = None
+
+        call = MagicMock()
+        call.data = {"device_id": "nonexistent_device"}
+
+        with pytest.raises(ServiceValidationError, match="not found"):
+            await async_handle_refresh_account_data(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_refresh_specific_device_connection_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test refreshing specific device with ConnectionError raises HomeAssistantError."""
+        mock_coordinator.async_refresh = AsyncMock(
+            side_effect=ConnectionError("Connection failed")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        with pytest.raises(HomeAssistantError, match="Device communication failed"):
+            await async_handle_refresh_account_data(mock_hass, call)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.hass_dyson.services._get_coordinator_from_device_id")
+    async def test_refresh_specific_device_generic_error(
+        self, mock_get_coord, mock_hass, mock_coordinator
+    ):
+        """Test refreshing specific device with generic Exception raises HomeAssistantError."""
+        mock_coordinator.async_refresh = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+        mock_get_coord.return_value = mock_coordinator
+
+        call = MagicMock()
+        call.data = {"device_id": "test_device"}
+
+        with pytest.raises(HomeAssistantError, match="Failed to refresh"):
+            await async_handle_refresh_account_data(mock_hass, call)
+
+    @pytest.mark.asyncio
+    async def test_refresh_all_devices_success(self, mock_hass, mock_coordinator):
+        """Test refreshing all devices when no device_id provided."""
+        from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+        mock_coordinator_spec = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coordinator_spec.serial_number = "VS6-EU-HJA1234A"
+        mock_coordinator_spec.async_refresh = AsyncMock()
+
+        mock_hass.data = {DOMAIN: {"key1": mock_coordinator_spec}}
+
+        call = MagicMock()
+        call.data = {}  # No device_id
+
+        await async_handle_refresh_account_data(mock_hass, call)
+
+        mock_coordinator_spec.async_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_all_devices_connection_error_continues(self, mock_hass):
+        """Test refreshing all devices continues past ConnectionError."""
+        from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+        mock_coord1 = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coord1.serial_number = "DEVICE_1"
+        mock_coord1.async_refresh = AsyncMock(
+            side_effect=ConnectionError("Device 1 failed")
+        )
+
+        mock_coord2 = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coord2.serial_number = "DEVICE_2"
+        mock_coord2.async_refresh = AsyncMock()
+
+        mock_hass.data = {DOMAIN: {"k1": mock_coord1, "k2": mock_coord2}}
+
+        call = MagicMock()
+        call.data = {}
+
+        # Should not raise - errors are logged and skipped
+        await async_handle_refresh_account_data(mock_hass, call)
+
+        mock_coord2.async_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_all_devices_generic_error_continues(self, mock_hass):
+        """Test refreshing all devices continues past generic Exception."""
+        from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+        mock_coord = MagicMock(spec=DysonDataUpdateCoordinator)
+        mock_coord.serial_number = "DEVICE_1"
+        mock_coord.async_refresh = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+
+        mock_hass.data = {DOMAIN: {"k1": mock_coord}}
+
+        call = MagicMock()
+        call.data = {}
+
+        # Should not raise
+        await async_handle_refresh_account_data(mock_hass, call)


### PR DESCRIPTION
fix: correct the case where lecOnly devices are insufficient to create a cloud account hub
fix: store connection_category in all discovery flows
fix: cross-reference serial number in cloud discovery with devices found in bluetooth discovery cache
docs: update documentation to include light information
test: add test for lecOnly account scenario