### PR TITLE
refactor: best practices improvements

### DIFF
--- a/custom_components/hass_dyson/__init__.py
+++ b/custom_components/hass_dyson/__init__.py
@@ -115,20 +115,20 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS_MAP = {
-    Platform.CALENDAR: "calendar",
-    Platform.FAN: "fan",
-    Platform.SENSOR: "sensor",
-    Platform.BINARY_SENSOR: "binary_sensor",
-    Platform.BUTTON: "button",
-    Platform.NUMBER: "number",
-    Platform.SELECT: "select",
-    Platform.SWITCH: "switch",
-    Platform.VACUUM: "vacuum",
-    Platform.CLIMATE: "climate",
-    Platform.HUMIDIFIER: "humidifier",
-    Platform.IMAGE: "image",
-}
+PLATFORMS: list[Platform] = [
+    Platform.CALENDAR,
+    Platform.FAN,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SWITCH,
+    Platform.VACUUM,
+    Platform.CLIMATE,
+    Platform.HUMIDIFIER,
+    Platform.IMAGE,
+]
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:

--- a/custom_components/hass_dyson/coordinator.py
+++ b/custom_components/hass_dyson/coordinator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import re
 import time
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -34,6 +35,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed  # noqa: F401
 from homeassistant.helpers import instance_id as ha_instance_id
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from libdyson_rest import AsyncDysonClient
+from libdyson_rest.exceptions import DysonAPIError, DysonAuthError, DysonConnectionError
 
 from .const import (
     CONF_AUTO_ADD_DEVICES,
@@ -63,6 +66,10 @@ from .device import DysonDevice
 from .device_utils import mask_email, mask_serial
 
 _LOGGER = logging.getLogger(__name__)
+
+# Compiled regex patterns for culture/language normalisation (module-level for efficiency).
+_CULTURE_PATTERN = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
+_EXTENDED_CULTURE_PATTERN = re.compile(r"^([a-z]{2})-[A-Za-z]+-([A-Z]{2})$")
 
 
 # Sensitive config-entry field names that must be redacted from logs.
@@ -104,8 +111,6 @@ def _get_default_country_culture_for_coordinator(hass) -> tuple[str, str]:
             - country: 2-letter uppercase ISO 3166-1 alpha-2 code
             - culture: IETF language tag format (e.g., 'en-US')
     """
-    import re
-
     # Handle test mocks that might not have config attribute
     try:
         hass_config = getattr(hass, "config", None)
@@ -124,16 +129,10 @@ def _get_default_country_culture_for_coordinator(hass) -> tuple[str, str]:
         # Replace underscores with hyphens (e.g., 'zh_CN' -> 'zh-CN')
         ha_language = ha_language.replace("_", "-")
 
-        # Validate culture format: must be exactly 5 characters in xx-YY format
-        culture_pattern = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
-
-        # Extended BCP 47 format pattern (e.g., 'zh-Hans-CN', 'zh-Hant-TW')
-        extended_pattern = re.compile(r"^([a-z]{2})-[A-Za-z]+-([A-Z]{2})$")
-
-        if culture_pattern.match(ha_language):
+        if _CULTURE_PATTERN.match(ha_language):
             # Already in correct format (e.g., 'en-US')
             culture = ha_language
-        elif extended_match := extended_pattern.match(ha_language):
+        elif extended_match := _EXTENDED_CULTURE_PATTERN.match(ha_language):
             # Extended format like 'zh-Hans-CN' - extract language and country
             language_code = extended_match.group(1)
             country_code = extended_match.group(2)
@@ -254,6 +253,11 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(self, hass: HomeAssistant, config_entry) -> None:  # type: ignore
         """Initialize the coordinator."""
         self.config_entry = config_entry
+        # Cache serial number to avoid repeated config-entry dict lookups and
+        # debug log spam on every property access.
+        self._serial_number: str = config_entry.data.get(
+            CONF_SERIAL_NUMBER
+        ) or config_entry.data.get("device_serial_number", "unknown")
         self.device: DysonDevice | None = None
         self._device_capabilities: list[str] = []
         self._device_category: list[str] = []
@@ -267,7 +271,7 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}_{config_entry.data[CONF_SERIAL_NUMBER]}",
+            name=f"{DOMAIN}_{self._serial_number}",
             update_interval=timedelta(seconds=DEFAULT_DEVICE_POLLING_INTERVAL),
         )
 
@@ -708,27 +712,13 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @property
     def serial_number(self) -> str:
-        """Return device serial number."""
-        # Debug logging to see what's in the config data. Sensitive fields like
-        # auth_token are redacted before logging so user-shared logs don't leak
-        # account credentials.
-        _LOGGER.debug("Config entry data keys: %s", list(self.config_entry.data.keys()))
-        _LOGGER.debug(
-            "Config entry data: %s", _redact_sensitive(self.config_entry.data)
-        )
-
-        # Handle both legacy single-device entries and new account-level entries
-        if CONF_SERIAL_NUMBER in self.config_entry.data:
-            serial = self.config_entry.data[CONF_SERIAL_NUMBER]
-            _LOGGER.debug("Found serial_number in config: %s", mask_serial(serial))
-            return serial
-        else:
-            # For account-level entries, serial number should be passed differently
-            serial = self.config_entry.data.get("device_serial_number", "unknown")
-            _LOGGER.debug(
-                "Using device_serial_number fallback: %s", mask_serial(serial)
-            )
-            return serial
+        """Return device serial number (cached at init, with fallback for test stubs)."""
+        sn = getattr(self, "_serial_number", None)
+        if sn:
+            return sn
+        return self.config_entry.data.get(
+            CONF_SERIAL_NUMBER
+        ) or self.config_entry.data.get("device_serial_number", "unknown")
 
     @property
     def device_name(self) -> str:
@@ -876,8 +866,6 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _authenticate_cloud_client(self):
         """Authenticate and return a cloud client."""
-        from libdyson_rest import AsyncDysonClient
-
         auth_token = self.config_entry.data.get("auth_token")
         # Get credential (email or phone number) from config entry
         credential = self.config_entry.data.get("email")
@@ -905,15 +893,12 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 credential,
             )
 
-            def create_client_with_token():
-                return AsyncDysonClient(
-                    email=credential,
-                    auth_token=auth_token,
-                    country=country,
-                    culture=culture,
-                )
-
-            return await self.hass.async_add_executor_job(create_client_with_token)
+            return AsyncDysonClient(
+                email=credential,
+                auth_token=auth_token,
+                country=country,
+                culture=culture,
+            )
         elif credential and password:
             # Legacy authentication method - follow same pattern as config_flow
             # Get country and culture from HA config
@@ -926,15 +911,12 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 culture,
             )
 
-            def create_client():
-                return AsyncDysonClient(
-                    email=credential,
-                    password=password,
-                    country=country,
-                    culture=culture,
-                )
-
-            cloud_client = await self.hass.async_add_executor_job(create_client)
+            cloud_client = AsyncDysonClient(
+                email=credential,
+                password=password,
+                country=country,
+                culture=culture,
+            )
 
             # Follow the same authentication sequence as the working script
             try:
@@ -1894,12 +1876,6 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_check_firmware_update(self) -> bool:
         """Check for available firmware updates using libdyson-rest >=0.7.0"""
-        from libdyson_rest.exceptions import (
-            DysonAPIError,
-            DysonAuthError,
-            DysonConnectionError,
-        )
-
         if self.config_entry.data.get(CONF_DISCOVERY_METHOD) != DISCOVERY_CLOUD:
             _LOGGER.debug(
                 "Firmware update check only available for cloud-discovered devices"
@@ -2456,8 +2432,6 @@ class DysonCloudAccountCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         # Initialize libdyson-rest client
-        from libdyson_rest import AsyncDysonClient
-
         if not self._auth_token:
             _LOGGER.warning(
                 "No auth token available for cloud account %s", mask_email(self._email)

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -11,14 +11,15 @@
   "documentation": "https://github.com/cmgrayb/hass-dyson",
   "homekit": {},
   "integration_type": "hub",
-  "iot_class": "local_polling",
+  "iot_class": "local_push",
   "issue_tracker": "https://github.com/cmgrayb/hass-dyson/issues",
   "loggers": [
     "custom_components.hass_dyson"
   ],
   "quality_scale": "gold",
   "requirements": [
-    "libdyson-rest==0.14.1"
+    "libdyson-rest==0.14.1",
+    "paho-mqtt>=2.1.0"
   ],
-  "version": "0.34.0"
+  "version": "0.35.0-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-dyson"
-version = "0.34.0"
+version = "0.35.0-beta.1"
 description = "Home Assistant Dyson integration focusing on device capabilities and connection information"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -29,12 +29,10 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aiohttp>=3.13.5",
     "cryptography>=45.0.7",
     "homeassistant==2026.6.0b0",
     "libdyson-rest==0.14.1",
     "paho-mqtt>=2.1.0",
-    "requests>=2.33.1",
 ]
 
 [project.optional-dependencies]
@@ -50,7 +48,6 @@ dev = [
     "responses==0.25.8",
     "ruff==0.15.15",
     "types-cryptography==3.3.23.2",
-    "types-requests==2.32.4.20260107",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@ pytest-cov>=7.1.0
 pytest-asyncio==1.4.0
 pytest-xdist==3.8.0
 mypy==2.1.0
-types-requests==2.32.4.20260107
 types-cryptography==3.3.23.2
 
 # Additional testing utilities

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -754,7 +754,9 @@ class TestDysonDataUpdateCoordinatorCloudSetup:
             }
             coordinator.config_entry = mock_config_entry
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
 
@@ -796,7 +798,9 @@ class TestDysonDataUpdateCoordinatorCloudSetup:
             }
             coordinator.config_entry = mock_config_entry
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
 
@@ -843,7 +847,9 @@ class TestDysonDataUpdateCoordinatorCloudSetup:
             }
             coordinator.config_entry = mock_config_entry
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
                 mock_challenge = MagicMock()

--- a/tests/test_coordinator_errors_simple.py
+++ b/tests/test_coordinator_errors_simple.py
@@ -142,22 +142,22 @@ class TestCoordinatorErrorHandling:
                 mock_fallback.assert_called_once()
 
     @patch("custom_components.hass_dyson.coordinator.DataUpdateCoordinator.__init__")
-    @patch("libdyson_rest.DysonClient")
+    @patch("custom_components.hass_dyson.coordinator.AsyncDysonClient")
     @pytest.mark.asyncio
     async def test_cloud_device_setup_authentication_failure(
-        self, mock_cloud_class, mock_super_init, mock_hass, mock_config_entry_cloud
+        self, mock_client_class, mock_super_init, mock_hass, mock_config_entry_cloud
     ):
         """Test cloud device setup with authentication failure."""
         mock_super_init.return_value = None
         coordinator = DysonDataUpdateCoordinator(mock_hass, mock_config_entry_cloud)
         coordinator.hass = mock_hass
-        coordinator.hass.async_add_executor_job = AsyncMock(
-            side_effect=RuntimeError("Authentication failed")
-        )
         coordinator._listeners = {}
         coordinator.config_entry = mock_config_entry_cloud
 
-        # Should raise RuntimeError (not wrapped for auth_token path)
+        # Simulate auth failure by making AsyncDysonClient constructor raise
+        mock_client_class.side_effect = RuntimeError("Authentication failed")
+
+        # Should raise RuntimeError propagated from client construction
         with pytest.raises(RuntimeError, match="Authentication failed"):
             await coordinator._authenticate_cloud_client()
 

--- a/tests/test_coordinator_final.py
+++ b/tests/test_coordinator_final.py
@@ -790,7 +790,9 @@ class TestDysonDataUpdateCoordinatorCloudSetup:
             }
             coordinator.config_entry = mock_config_entry
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
 
@@ -836,7 +838,9 @@ class TestDysonDataUpdateCoordinatorCloudSetup:
             }
             coordinator.config_entry = mock_config_entry
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
                 mock_challenge = MagicMock()
@@ -1382,16 +1386,14 @@ class TestDysonDataUpdateCoordinatorCloudAuth:
 
         mock_client = MagicMock()
 
-        # Ensure the coordinator's hass has async_add_executor_job as AsyncMock
-        coordinator.hass.async_add_executor_job = AsyncMock(return_value=mock_client)
-
-        with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+        with patch(
+            "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+        ) as mock_client_class:
             mock_client_class.return_value = mock_client
 
             result = await coordinator._authenticate_cloud_client()
 
             assert result == mock_client
-            coordinator.hass.async_add_executor_job.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_authenticate_cloud_client_with_username_password(self, mock_hass):
@@ -1423,7 +1425,9 @@ class TestDysonDataUpdateCoordinatorCloudAuth:
         mock_client.complete_login = AsyncMock()
         mock_client.close = AsyncMock()
 
-        with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+        with patch(
+            "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+        ) as mock_client_class:
             mock_client_class.return_value = mock_client
             # Ensure the coordinator's hass has async_add_executor_job as AsyncMock
             coordinator.hass.async_add_executor_job = AsyncMock(
@@ -1479,7 +1483,9 @@ class TestDysonDataUpdateCoordinatorCloudAuth:
         mock_client.provision = AsyncMock(side_effect=Exception("Auth failed"))
         mock_client.close = AsyncMock()
 
-        with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+        with patch(
+            "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+        ) as mock_client_class:
             mock_client_class.return_value = mock_client
             # Ensure the coordinator's hass has async_add_executor_job as AsyncMock
             coordinator.hass.async_add_executor_job = AsyncMock(
@@ -1509,7 +1515,9 @@ class TestDysonDataUpdateCoordinatorCloudAuth:
             coordinator.hass = mock_hass
             coordinator.config_entry = mock_config_entry_cloud_cn
 
-        with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+        with patch(
+            "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+        ) as mock_client_class:
             mock_client = AsyncMock()
             mock_client_class.return_value = mock_client
 
@@ -1735,7 +1743,9 @@ class TestDysonCloudAccountCoordinatorCNRegion:
                 }
             ]
 
-            with patch("libdyson_rest.AsyncDysonClient") as mock_client_class:
+            with patch(
+                "custom_components.hass_dyson.coordinator.AsyncDysonClient"
+            ) as mock_client_class:
                 # Mock the context manager behavior
                 mock_client = AsyncMock()
                 mock_client.get_devices = AsyncMock(return_value=mock_device_data)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from custom_components.hass_dyson import (
     CONFIG_SCHEMA,
     DEVICE_SCHEMA,
-    PLATFORMS_MAP,
+    PLATFORMS,
     _create_device_entry,
     _create_discovery_flow,
     _get_platforms_for_device,
@@ -80,8 +80,8 @@ class TestInitModule:
         assert "credential" in DEVICE_SCHEMA.schema
         assert "capabilities" in DEVICE_SCHEMA.schema
 
-    def test_platforms_map(self):
-        """Test PLATFORMS_MAP contains expected platforms."""
+    def test_platforms(self):
+        """Test PLATFORMS contains expected platforms."""
         expected_platforms = [
             Platform.FAN,
             Platform.SENSOR,
@@ -94,7 +94,7 @@ class TestInitModule:
             Platform.CLIMATE,
         ]
         for platform in expected_platforms:
-            assert platform in PLATFORMS_MAP
+            assert platform in PLATFORMS
 
     @pytest.mark.asyncio
     async def test_async_setup_no_devices(self, mock_hass):
@@ -345,14 +345,13 @@ class TestInitConstants:
         validated = CONFIG_SCHEMA(test_config)
         assert validated[DOMAIN]["devices"] == []
 
-    def test_platforms_map_completeness(self):
-        """Test that all expected platforms are mapped."""
-        assert len(PLATFORMS_MAP) >= 9  # At least 9 platforms should be supported
+    def test_platforms_completeness(self):
+        """Test that all expected platforms are listed."""
+        assert len(PLATFORMS) >= 9  # At least 9 platforms should be supported
 
-        # Check that all values are strings
-        for platform, name in PLATFORMS_MAP.items():
-            assert isinstance(name, str)
-            assert len(name) > 0
+        # Check that all values are Platform instances
+        for platform in PLATFORMS:
+            assert isinstance(platform, Platform)
 
 
 class TestInitBackgroundTasks:


### PR DESCRIPTION
fix: add paho-mqtt to manifest to ensure proper installation
fix: remove unused libraries from dependencies

refactor: cache _serial_number in `__init__` to reduce masking calls
refactor: call `AsyncDysonClient()` directly outside of executor wrapper
refactor: compile `_CULTURE_PATTERN` and `_EXTENDED_CULTURE_PATTERN` as module constants to reduce calls
refactor: move all `libdyson_rest` imports to module level
refactor: replace `PLATFORMS_MAP` with `PLATFORMS` as `list` object to directly call the platform objects