### PR TITLE
fix: installable libdyson-rest pin + map API probe hardening

### DIFF
--- a/custom_components/hass_dyson/coordinator.py
+++ b/custom_components/hass_dyson/coordinator.py
@@ -71,10 +71,13 @@ _LOGGER = logging.getLogger(__name__)
 _CULTURE_PATTERN = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
 _EXTENDED_CULTURE_PATTERN = re.compile(r"^([a-z]{2})-[A-Za-z]+-([A-Z]{2})$")
 
-# Matches any 3-digit HTTP status code in the 4xx or 5xx range inside an error
-# message string.  Used by async_discover_map_api_version to detect endpoint
-# incompatibility when probing the v1 clean-maps endpoint.
-_HTTP_ERROR_RE = re.compile(r"\b[45]\d{2}\b")
+# Extracts the HTTP status code from a libdyson-rest error message.  httpx
+# renders status failures as "Client error '404 Not Found' for url '...'" /
+# "Server error '500 Internal Server Error' for url '...'", and DysonAPIError
+# wraps that text verbatim.  Anchoring on that shape — rather than matching any
+# 3-digit number — keeps digit groups in URLs or serial numbers from being
+# mistaken for HTTP statuses.  Used by async_discover_map_api_version.
+_HTTP_STATUS_RE = re.compile(r"\b(?:Client|Server) error '([45]\d{2})\b")
 
 
 # Sensitive config-entry field names that must be redacted from logs.
@@ -368,17 +371,33 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Probe and cache the map-endpoint API version for this device.
 
         Calls ``get_clean_maps`` with ``api_version=1`` as a lightweight probe
-        (dust maps excluded so no large payloads are transferred).  If the
-        server returns a 4xx or 5xx response the device requires v2 endpoints
-        and the result is cached.  Subsequent calls return the cached value
-        immediately without any network request.
+        (dust maps excluded so no large payloads are transferred).
+
+        Outcomes:
+
+        - Probe succeeds → the device is served by the v1 endpoints
+          (360 Vis Nav); ``1`` is cached.
+        - Probe fails with a definitive HTTP 4xx → the device is not served
+          by the v1 endpoints (360 Spot+Clean / Spot+Scrub and newer);
+          ``2`` is cached.
+        - Probe fails with an HTTP 5xx → ambiguous: a v2-only device sees
+          this, but so does a Vis Nav during a transient cloud incident.
+          ``2`` is returned for this call but NOT cached, so a Vis Nav is
+          not locked onto v2 endpoints (which fail for it) until the next
+          restart — the probe re-runs on the next map call and recovers
+          together with the cloud.
+        - Auth or non-HTTP errors → ``1`` is returned without caching and
+          the caller surfaces the underlying failure.
+
+        Once a result is cached, subsequent calls return it immediately
+        without any network request.
 
         Args:
             client: An authenticated ``AsyncDysonClient`` instance.
 
         Returns:
-            ``1`` for Dyson 360 Vis Nav (v1 endpoints respond successfully),
-            ``2`` for Dyson 360 Spot+Clean / Spot+Scrub and newer devices.
+            ``1`` for v1-served devices (360 Vis Nav), ``2`` for v2-served
+            devices (360 Spot+Clean / Spot+Scrub and newer).
         """
         if self._map_api_version is not None:
             return self._map_api_version
@@ -404,17 +423,11 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return 1
         except DysonAPIError as err:
             err_str = str(err)
-            if _HTTP_ERROR_RE.search(err_str):
-                self._map_api_version = 2
-                _LOGGER.info(
-                    "Map API version for %s: v2 "
-                    "(v1 probe returned '%s' — device uses v2 endpoints)",
-                    self.serial_number,
-                    err_str,
-                )
-            else:
-                # Non-HTTP error (connection failure, timeout, etc.);
-                # do not cache so the next call retries the probe.
+            status_match = _HTTP_STATUS_RE.search(err_str)
+            if status_match is None:
+                # Non-HTTP error (connection failure, unexpected response
+                # shape, etc.); do not cache so the next call retries the
+                # probe.
                 _LOGGER.warning(
                     "Map API version probe for %s: unexpected error '%s'"
                     " — defaulting to v1 for this call",
@@ -422,6 +435,27 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     err_str,
                 )
                 return 1
+            status = int(status_match.group(1))
+            if status >= 500:
+                # Ambiguous: a v2-only device sees a 5xx on v1, but so does
+                # a Vis Nav during a transient cloud incident.  Use v2 for
+                # this call without caching; callers fall back to their
+                # stale TTL caches if v2 then fails, and the next map call
+                # re-probes.
+                _LOGGER.warning(
+                    "Map API version probe for %s: v1 endpoint returned"
+                    " HTTP %d — using v2 for this call without caching",
+                    self.serial_number,
+                    status,
+                )
+                return 2
+            self._map_api_version = 2
+            _LOGGER.info(
+                "Map API version for %s: v2 (v1 probe returned HTTP %d"
+                " — device uses v2 endpoints)",
+                self.serial_number,
+                status,
+            )
 
         return self._map_api_version
 

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -18,7 +18,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "libdyson-rest==0.15.1-beta.1",
+    "libdyson-rest==0.16.0b1",
     "paho-mqtt>=2.1.0"
   ],
   "version": "0.35.0"

--- a/tests/test_coordinator_map_api_version.py
+++ b/tests/test_coordinator_map_api_version.py
@@ -146,9 +146,7 @@ class TestAsyncDiscoverMapApiVersion:
         assert client.get_clean_maps.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_status_extraction_ignores_digit_groups_in_message(
-        self, coordinator
-    ):
+    async def test_status_extraction_ignores_digit_groups_in_message(self, coordinator):
         """Digit groups in serials/URLs are not mistaken for HTTP statuses."""
         client = _client(
             side_effect=DysonAPIError(

--- a/tests/test_coordinator_map_api_version.py
+++ b/tests/test_coordinator_map_api_version.py
@@ -1,0 +1,160 @@
+"""Tests for DysonDataUpdateCoordinator.async_discover_map_api_version.
+
+Covers the map-endpoint API version probe: caching of definitive results,
+non-caching of transient failures, and HTTP-status extraction from
+libdyson-rest error messages.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from libdyson_rest.exceptions import DysonAPIError, DysonAuthError
+
+from custom_components.hass_dyson.const import (
+    CONF_DISCOVERY_METHOD,
+    CONF_SERIAL_NUMBER,
+    DISCOVERY_CLOUD,
+)
+from custom_components.hass_dyson.coordinator import DysonDataUpdateCoordinator
+
+PROBE_404 = (
+    "Failed to get clean maps: Client error '404 Not Found' for url "
+    "'https://appapi.cp.dyson.com/v1/VS9-GB-HJA0000A/clean-maps'"
+)
+PROBE_500 = (
+    "Failed to get clean maps: Server error '500 Internal Server Error' for url "
+    "'https://appapi.cp.dyson.com/v1/VS9-GB-HJA0000A/clean-maps'"
+)
+
+
+@pytest.fixture
+def pure_mock_hass():
+    """Create a minimal mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.add_job = MagicMock()
+    hass.bus = MagicMock()
+    hass.config = MagicMock()
+    hass.config.country = "US"
+    hass.config.language = "en"
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def mock_config_entry_cloud():
+    """Mock config entry for a cloud-discovered robot."""
+    config_entry = MagicMock()
+    config_entry.data = {
+        CONF_DISCOVERY_METHOD: DISCOVERY_CLOUD,
+        CONF_SERIAL_NUMBER: "VS9-GB-HJA0000A",
+        "username": "test@example.com",
+        "auth_token": "test_token_123",
+        "capabilities": [],
+        "device_category": "robot",
+    }
+    config_entry.entry_id = "test_entry_probe"
+    return config_entry
+
+
+@pytest.fixture
+def coordinator(pure_mock_hass, mock_config_entry_cloud):
+    """Create a coordinator with patched parent initialisation."""
+    with patch(
+        "custom_components.hass_dyson.coordinator.DataUpdateCoordinator.__init__",
+        return_value=None,
+    ):
+        coordinator = DysonDataUpdateCoordinator(
+            pure_mock_hass, mock_config_entry_cloud
+        )
+    coordinator.hass = pure_mock_hass
+    coordinator._listeners = {}
+    return coordinator
+
+
+def _client(**get_clean_maps_kwargs):
+    """Create a mock cloud client with a configurable get_clean_maps."""
+    client = MagicMock()
+    client.get_clean_maps = AsyncMock(**get_clean_maps_kwargs)
+    return client
+
+
+class TestAsyncDiscoverMapApiVersion:
+    """Test the map API version probe outcomes and caching behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_probe_success_returns_and_caches_v1(self, coordinator):
+        """A successful v1 probe returns 1 and caches it."""
+        client = _client(return_value=[])
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert coordinator._map_api_version == 1
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        client.get_clean_maps.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_probe_definitive_4xx_returns_and_caches_v2(self, coordinator):
+        """A 404 from the v1 endpoint means a v2-only device; 2 is cached."""
+        client = _client(side_effect=DysonAPIError(PROBE_404))
+
+        assert await coordinator.async_discover_map_api_version(client) == 2
+        assert coordinator._map_api_version == 2
+
+        assert await coordinator.async_discover_map_api_version(client) == 2
+        client.get_clean_maps.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_probe_5xx_returns_v2_without_caching(self, coordinator):
+        """A 5xx is ambiguous: v2 is used for the call but never cached."""
+        client = _client(side_effect=DysonAPIError(PROBE_500))
+
+        assert await coordinator.async_discover_map_api_version(client) == 2
+        assert coordinator._map_api_version is None
+
+        assert await coordinator.async_discover_map_api_version(client) == 2
+        assert client.get_clean_maps.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_probe_recovers_after_transient_5xx(self, coordinator):
+        """A Vis Nav is not locked onto v2 by a transient v1 outage."""
+        client = _client(side_effect=[DysonAPIError(PROBE_500), []])
+
+        assert await coordinator.async_discover_map_api_version(client) == 2
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert coordinator._map_api_version == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_auth_error_returns_v1_without_caching(self, coordinator):
+        """Auth failures are not version signals; nothing is cached."""
+        client = _client(side_effect=DysonAuthError("Authentication token expired"))
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert coordinator._map_api_version is None
+
+    @pytest.mark.asyncio
+    async def test_probe_non_http_error_returns_v1_without_caching(self, coordinator):
+        """Connection/shape errors default to v1 and retry on the next call."""
+        client = _client(
+            side_effect=DysonAPIError("Expected list in clean-maps response")
+        )
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert coordinator._map_api_version is None
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert client.get_clean_maps.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_status_extraction_ignores_digit_groups_in_message(
+        self, coordinator
+    ):
+        """Digit groups in serials/URLs are not mistaken for HTTP statuses."""
+        client = _client(
+            side_effect=DysonAPIError(
+                "Failed to get clean maps: connection reset for device VS6-EU-521ABCD"
+            )
+        )
+
+        assert await coordinator.async_discover_map_api_version(client) == 1
+        assert coordinator._map_api_version is None


### PR DESCRIPTION
Refs #392.

Two fixes for the v0.35.1 beta line, verified against a live AU 360 Vis Nav (H8W) that hit the #392 regression.

### 1. `manifest.json` pins a libdyson-rest version that isn't on PyPI

`libdyson-rest==0.15.1-beta.1` was never published — PyPI's 0.15.x line ends at `0.15.0`, and the `api_version` changes are released as **`0.16.0b1`** (which `pyproject.toml` already points at). Because HA Core installs integration requirements from `manifest.json` while CI installs from `pyproject.toml`, CI passes but a user installing `v0.35.1-beta.1` gets a failed requirement install and the integration doesn't set up at all — which may be why #392 has no beta feedback yet. Re-pinned to `0.16.0b1`; its keyword signatures match the existing call sites.

### 2. Probe: don't cache `api_version=2` on a transient v1 5xx

`async_discover_map_api_version` cached v2 whenever the v1 probe error contained any 4xx/5xx status. A one-off v1 500 at probe time (cloud incident — exactly what Vis Navs saw during the #392 window) would lock a v1 device onto v2 endpoints, which 500 for it, until the next restart — recreating the outage the probe is meant to solve.

Now:

- definitive **4xx** → cache v2 (device isn't served by v1: Spot+Clean / Spot+Scrub and newer)
- **5xx** → use v2 for that call **without caching**, so the next map call re-probes and a Vis Nav recovers together with the cloud; callers meanwhile fall back to their stale TTL caches
- auth / non-HTTP errors → unchanged behaviour (v1, uncached)

Status extraction is now anchored on the httpx error format (`Client error '404 …'` / `Server error '500 …'`, which `DysonAPIError` wraps verbatim) instead of matching any 3-digit number in the message — the previous pattern could false-positive on digit groups in URLs or serials (e.g. a serial segment like `-521`).

Adds direct unit tests for all probe outcomes in `tests/test_coordinator_map_api_version.py` — the probe previously had none, and the 18 uncovered lines codecov flagged on #394 are exactly what the new module exercises.

### Field validation

With my account token against the live API (AU Vis Nav): v2 `persistent-map-metadata` → 500 while v1 → 200 (both maps, full zones); v2 `clean-maps` → 200 but empty `[]` while v1 → 200 with the full history; and a local build using the v1 endpoints restored zone buttons, `last_clean` sensors, and the dust map on this device.

Also noting `release/v0.36.0` still pins `libdyson-rest==0.15.0`, so the regression returns in the 0.36 line unless this is forward-ported.
