### PR TITLE
feat: keep zone-button recovery available when the cloud fetch fails

### DIFF
--- a/custom_components/hass_dyson/button.py
+++ b/custom_components/hass_dyson/button.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from libdyson_rest.models import PersistentMapMeta, ZoneMeta
 
 from .const import DEVICE_CATEGORY_ROBOT, DOMAIN
@@ -17,6 +19,11 @@ from .coordinator import DysonDataUpdateCoordinator
 from .entity import DysonEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+# Retry schedule (seconds) for zone-button discovery when the cloud fetch
+# fails during setup.  After the schedule is exhausted the Refresh Zone List
+# button remains available for manual recovery.
+ZONE_DISCOVERY_RETRY_DELAYS: tuple[float, ...] = (60.0, 300.0, 900.0)
 
 
 async def async_setup_entry(
@@ -31,47 +38,108 @@ async def async_setup_entry(
         return
     coordinator: DysonDataUpdateCoordinator = entry_data
 
-    entities: list[ButtonEntity] = [DysonReconnectButton(coordinator)]
-
     # Robot vacuums (Vis Nav): auto-discover per-zone clean buttons from the
     # persistent-map metadata fetched from the Dyson cloud.
     is_robot = any(
         cat == DEVICE_CATEGORY_ROBOT for cat in (coordinator.device_category or [])
     )
     has_token = bool(coordinator.config_entry.data.get("auth_token"))
-    if is_robot and has_token:
+
+    if not (is_robot and has_token):
+        async_add_entities([DysonReconnectButton(coordinator)], True)
+        return
+
+    known_zone_ids: set[str] = set()
+
+    async def _async_discover_zone_buttons() -> int:
+        """Fetch map metadata and add buttons for zones not yet seen.
+
+        Returns the number of buttons added; raises if the cloud fetch fails.
+        """
         # Lazy import to avoid a setup-time circular dependency with services.py.
         from .services import _fetch_persistent_map_metadata
 
-        try:
-            maps = await _fetch_persistent_map_metadata(coordinator)
-        except Exception as err:  # noqa: BLE001 — never block setup over zone discovery
-            _LOGGER.warning(
-                "Could not fetch persistent map for %s; skipping zone buttons: %s",
-                coordinator.serial_number,
-                err,
-            )
-            maps = []
+        maps = await _fetch_persistent_map_metadata(coordinator)
 
-        # Most robots have a single persistent map; iterate to handle multi-map setups.
-        seen_zone_ids: set[str] = set()
+        # Most robots have a single persistent map; iterate to handle multi-map
+        # setups.
+        new_buttons: list[ButtonEntity] = []
         for pmap in maps:
             for zone in pmap.zones:
                 zone_id = zone.id
-                if not zone_id or zone_id in seen_zone_ids:
+                if not zone_id or zone_id in known_zone_ids:
                     continue
-                seen_zone_ids.add(zone_id)
-                entities.append(DysonZoneCleanButton(coordinator, pmap, zone))
+                known_zone_ids.add(zone_id)
+                new_buttons.append(DysonZoneCleanButton(coordinator, pmap, zone))
 
-        if seen_zone_ids:
-            entities.append(DysonRefreshZonesButton(coordinator))
+        if new_buttons:
+            async_add_entities(new_buttons, True)
             _LOGGER.info(
                 "Created %d per-zone clean buttons for %s",
-                len(seen_zone_ids),
+                len(new_buttons),
                 coordinator.serial_number,
             )
+        return len(new_buttons)
 
-    async_add_entities(entities, True)
+    # The reconnect and refresh buttons are created unconditionally so a
+    # failed cloud fetch never removes the manual recovery path.
+    async_add_entities(
+        [
+            DysonReconnectButton(coordinator),
+            DysonRefreshZonesButton(coordinator, _async_discover_zone_buttons),
+        ],
+        True,
+    )
+
+    try:
+        await _async_discover_zone_buttons()
+    except Exception as err:  # noqa: BLE001 — never block setup over zone discovery
+        _LOGGER.warning(
+            "Could not fetch persistent map for %s; retrying zone-button"
+            " discovery in the background: %s",
+            coordinator.serial_number,
+            err,
+        )
+    else:
+        return
+
+    # Retry on a backoff schedule so the buttons reappear without a Home
+    # Assistant restart once the cloud recovers.
+    retry_delays = iter(ZONE_DISCOVERY_RETRY_DELAYS)
+    cancel_retry: CALLBACK_TYPE | None = None
+
+    async def _async_retry(_now) -> None:
+        nonlocal cancel_retry
+        cancel_retry = None
+        try:
+            await _async_discover_zone_buttons()
+        except Exception as err:  # noqa: BLE001 — keep retrying on the schedule
+            _LOGGER.debug(
+                "Zone-button discovery retry failed for %s: %s",
+                coordinator.serial_number,
+                err,
+            )
+            _schedule_retry()
+
+    def _schedule_retry() -> None:
+        nonlocal cancel_retry
+        delay = next(retry_delays, None)
+        if delay is None:
+            _LOGGER.warning(
+                "Zone-button discovery for %s did not succeed after %d retries;"
+                " press the Refresh Zone List button to retry",
+                coordinator.serial_number,
+                len(ZONE_DISCOVERY_RETRY_DELAYS),
+            )
+            return
+        cancel_retry = async_call_later(hass, delay, _async_retry)
+
+    def _cancel_pending_retry() -> None:
+        if cancel_retry is not None:
+            cancel_retry()
+
+    config_entry.async_on_unload(_cancel_pending_retry)
+    _schedule_retry()
 
 
 class DysonReconnectButton(DysonEntity, ButtonEntity):
@@ -169,18 +237,23 @@ class DysonZoneCleanButton(DysonEntity, ButtonEntity):
 
 
 class DysonRefreshZonesButton(DysonEntity, ButtonEntity):
-    """Force re-fetch of the persistent map metadata from the Dyson cloud.
+    """Re-fetch the persistent map metadata from the Dyson cloud.
 
     Invalidates the in-process cache used by the start_zone_clean service and
-    zone-clean buttons. To pick up newly added/renamed zones in the HA UI,
-    restart Home Assistant after pressing this button (entities are only
-    created at integration setup).
+    zone-clean buttons, then adds buttons for any newly-discovered zones
+    without requiring a restart.  Renamed zones keep their entity (unique_id
+    is the zone id) and pick up the new name after a Home Assistant restart.
     """
 
     coordinator: DysonDataUpdateCoordinator
 
-    def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: DysonDataUpdateCoordinator,
+        discover_zone_buttons: Callable[[], Awaitable[int]] | None = None,
+    ) -> None:
         super().__init__(coordinator)
+        self._discover_zone_buttons = discover_zone_buttons
         self._attr_unique_id = f"{coordinator.serial_number}_refresh_zones"
         self._attr_name = "Refresh Zone List"
         self._attr_icon = "mdi:refresh"
@@ -191,6 +264,14 @@ class DysonRefreshZonesButton(DysonEntity, ButtonEntity):
 
         _persistent_map_cache.invalidate(self.coordinator.serial_number)
         try:
+            if self._discover_zone_buttons is not None:
+                added = await self._discover_zone_buttons()
+                _LOGGER.info(
+                    "Refreshed persistent map for %s: %d new zone button(s) added",
+                    self.coordinator.serial_number,
+                    added,
+                )
+                return
             maps = await _fetch_persistent_map_metadata(self.coordinator)
             _LOGGER.info(
                 "Refreshed persistent map for %s: %d map(s), %d zone(s) total. "

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -630,9 +630,7 @@ class TestZoneDiscoveryRetry:
         discover.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_refresh_press_discovery_failure_raises(
-        self, mock_robot_coordinator
-    ):
+    async def test_refresh_press_discovery_failure_raises(self, mock_robot_coordinator):
         """Discovery failures on refresh surface as HomeAssistantError."""
         discover = AsyncMock(side_effect=Exception("cloud down"))
         btn = DysonRefreshZonesButton(mock_robot_coordinator, discover)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 from libdyson_rest.models import PersistentMapMeta, ZoneMeta
 
 from custom_components.hass_dyson.button import (
+    ZONE_DISCOVERY_RETRY_DELAYS,
     DysonReconnectButton,
     DysonRefreshZonesButton,
     DysonZoneCleanButton,
@@ -376,32 +377,43 @@ class TestButtonPlatformRobotSetup:
         ):
             await async_setup_entry(mock_hass, mock_config_entry, add_entities)
 
-        add_entities.assert_called_once()
-        entities = add_entities.call_args[0][0]
-        # reconnect + 2 zone buttons + refresh button
-        assert len(entities) == 4
-        assert isinstance(entities[0], DysonReconnectButton)
-        assert isinstance(entities[1], DysonZoneCleanButton)
-        assert isinstance(entities[2], DysonZoneCleanButton)
-        assert isinstance(entities[3], DysonRefreshZonesButton)
+        # Base call: reconnect + refresh; second call: the discovered zones
+        assert add_entities.call_count == 2
+        base = add_entities.call_args_list[0][0][0]
+        assert len(base) == 2
+        assert isinstance(base[0], DysonReconnectButton)
+        assert isinstance(base[1], DysonRefreshZonesButton)
+        zones = add_entities.call_args_list[1][0][0]
+        assert len(zones) == 2
+        assert all(isinstance(entity, DysonZoneCleanButton) for entity in zones)
 
     @pytest.mark.asyncio
-    async def test_robot_zone_fetch_exception_skips_zones(
+    async def test_robot_zone_fetch_exception_defers_discovery(
         self, mock_hass, mock_config_entry, mock_robot_coordinator
     ):
-        """Exception during zone fetch logs a warning and skips zone buttons."""
+        """Exception during zone fetch keeps recovery buttons and schedules a retry."""
         mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
         add_entities = MagicMock()
-        with patch(
-            "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
-            AsyncMock(side_effect=Exception("network error")),
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(side_effect=Exception("network error")),
+            ),
+            patch(
+                "custom_components.hass_dyson.button.async_call_later"
+            ) as mock_call_later,
         ):
             await async_setup_entry(mock_hass, mock_config_entry, add_entities)
 
+        # Reconnect + refresh are still created — no zone buttons yet
+        add_entities.assert_called_once()
         entities = add_entities.call_args[0][0]
-        # Only reconnect button — no zone buttons added
-        assert len(entities) == 1
+        assert len(entities) == 2
         assert isinstance(entities[0], DysonReconnectButton)
+        assert isinstance(entities[1], DysonRefreshZonesButton)
+        # The first background retry is scheduled
+        mock_call_later.assert_called_once()
+        assert mock_call_later.call_args[0][1] == ZONE_DISCOVERY_RETRY_DELAYS[0]
 
     @pytest.mark.asyncio
     async def test_robot_empty_maps_no_zone_buttons(
@@ -410,15 +422,24 @@ class TestButtonPlatformRobotSetup:
         """Robot with empty persistent map list creates no zone buttons."""
         mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
         add_entities = MagicMock()
-        with patch(
-            "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
-            AsyncMock(return_value=[]),
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "custom_components.hass_dyson.button.async_call_later"
+            ) as mock_call_later,
         ):
             await async_setup_entry(mock_hass, mock_config_entry, add_entities)
 
+        # Recovery buttons only; a successful-but-empty fetch schedules no retry
+        add_entities.assert_called_once()
         entities = add_entities.call_args[0][0]
-        assert len(entities) == 1
+        assert len(entities) == 2
         assert isinstance(entities[0], DysonReconnectButton)
+        assert isinstance(entities[1], DysonRefreshZonesButton)
+        mock_call_later.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_duplicate_zone_ids_deduplicated(
@@ -447,9 +468,10 @@ class TestButtonPlatformRobotSetup:
         ):
             await async_setup_entry(mock_hass, mock_config_entry, add_entities)
 
-        entities = add_entities.call_args[0][0]
-        # reconnect + 1 unique zone + refresh
-        assert len(entities) == 3
+        zones = add_entities.call_args_list[1][0][0]
+        # 1 unique zone across both maps
+        assert len(zones) == 1
+        assert isinstance(zones[0], DysonZoneCleanButton)
 
     @pytest.mark.asyncio
     async def test_non_robot_with_token_no_zone_buttons(
@@ -478,6 +500,145 @@ class TestButtonPlatformRobotSetup:
         entities = add_entities.call_args[0][0]
         assert len(entities) == 1
         assert isinstance(entities[0], DysonReconnectButton)
+
+
+# ---------------------------------------------------------------------------
+# Tests: zone discovery retry + manual recovery
+# ---------------------------------------------------------------------------
+
+
+class TestZoneDiscoveryRetry:
+    """Test background retry and manual recovery for zone discovery."""
+
+    _FAKE_MAPS = [
+        PersistentMapMeta(
+            id="map-1",
+            name=None,
+            zones_definition_last_updated_date=None,
+            zones=[
+                ZoneMeta(id="z1", name="Kitchen", icon="kitchen", area=None),
+                ZoneMeta(id="z2", name="Bedroom", icon="bedroom", area=None),
+            ],
+        )
+    ]
+
+    @pytest.mark.asyncio
+    async def test_retry_adds_zone_buttons_after_recovery(
+        self, mock_hass, mock_config_entry, mock_robot_coordinator
+    ):
+        """A scheduled retry adds the zone buttons once the cloud recovers."""
+        mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
+        add_entities = MagicMock()
+        scheduled = []
+
+        def fake_call_later(hass, delay, action):
+            scheduled.append((delay, action))
+            return MagicMock()
+
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(side_effect=[Exception("cloud down"), self._FAKE_MAPS]),
+            ),
+            patch(
+                "custom_components.hass_dyson.button.async_call_later",
+                side_effect=fake_call_later,
+            ),
+        ):
+            await async_setup_entry(mock_hass, mock_config_entry, add_entities)
+            assert add_entities.call_count == 1
+            assert len(scheduled) == 1
+            await scheduled[0][1](None)
+
+        assert add_entities.call_count == 2
+        zones = add_entities.call_args_list[1][0][0]
+        assert len(zones) == 2
+        assert all(isinstance(entity, DysonZoneCleanButton) for entity in zones)
+
+    @pytest.mark.asyncio
+    async def test_retry_schedule_exhausts_with_backoff(
+        self, mock_hass, mock_config_entry, mock_robot_coordinator
+    ):
+        """Retries follow the backoff schedule and stop when it is exhausted."""
+        mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
+        add_entities = MagicMock()
+        delays_seen: list[float] = []
+        pending = []
+
+        def fake_call_later(hass, delay, action):
+            delays_seen.append(delay)
+            pending.append(action)
+            return MagicMock()
+
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(side_effect=Exception("cloud down")),
+            ),
+            patch(
+                "custom_components.hass_dyson.button.async_call_later",
+                side_effect=fake_call_later,
+            ),
+        ):
+            await async_setup_entry(mock_hass, mock_config_entry, add_entities)
+            while pending:
+                await pending.pop(0)(None)
+
+        assert delays_seen == list(ZONE_DISCOVERY_RETRY_DELAYS)
+        # Only the base reconnect + refresh call — no zone buttons were added
+        assert add_entities.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unload_cancels_pending_retry(
+        self, mock_hass, mock_config_entry, mock_robot_coordinator
+    ):
+        """Unloading the entry cancels a pending discovery retry."""
+        mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
+        add_entities = MagicMock()
+        cancel = MagicMock()
+
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(side_effect=Exception("cloud down")),
+            ),
+            patch(
+                "custom_components.hass_dyson.button.async_call_later",
+                return_value=cancel,
+            ),
+        ):
+            await async_setup_entry(mock_hass, mock_config_entry, add_entities)
+
+        mock_config_entry.async_on_unload.assert_called_once()
+        unload_callback = mock_config_entry.async_on_unload.call_args[0][0]
+        unload_callback()
+        cancel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_press_adds_new_zones_without_restart(
+        self, mock_robot_coordinator
+    ):
+        """Pressing refresh invalidates the cache and adds new zone buttons."""
+        discover = AsyncMock(return_value=3)
+        btn = DysonRefreshZonesButton(mock_robot_coordinator, discover)
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache"
+        ) as mock_cache:
+            await btn.async_press()
+
+        mock_cache.invalidate.assert_called_once_with("VS9-GB-HJA0000A")
+        discover.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_press_discovery_failure_raises(
+        self, mock_robot_coordinator
+    ):
+        """Discovery failures on refresh surface as HomeAssistantError."""
+        discover = AsyncMock(side_effect=Exception("cloud down"))
+        btn = DysonRefreshZonesButton(mock_robot_coordinator, discover)
+        with patch("custom_components.hass_dyson.services._persistent_map_cache"):
+            with pytest.raises(HomeAssistantError, match="Failed to refresh zones"):
+                await btn.async_press()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #392.

During the #392 outage, a failed persistent-map fetch at setup didn't just skip the zone-clean buttons — it also skipped the **Refresh Zone List** button (it was only created when `seen_zone_ids` was non-empty), so there was no recovery short of restarting Home Assistant and hoping the cloud was back. Any future transient cloud failure at startup reproduces that, regardless of endpoint version.

Changes:

- The reconnect + refresh buttons are created unconditionally for cloud-enabled robots, so the manual recovery path always exists.
- If the setup-time fetch fails, zone discovery retries in the background (60 s / 5 min / 15 min), adding the buttons as soon as the cloud recovers — no restart needed. Pending retries are cancelled on entry unload.
- Pressing **Refresh Zone List** now adds newly-discovered zone buttons immediately (previously new entities only appeared after a restart, as its docstring noted). Renamed zones still pick up the new name on restart, since names are set at entity creation.

Existing zone-setup tests are updated for the new behaviour, plus new coverage for the retry schedule, exhaustion, unload cancellation, and refresh-press discovery (`TestZoneDiscoveryRetry`).

Based on `release/v0.35.1`; happy to retarget to `release/v0.36.0` if you'd rather take it there.
