### PR TITLE
feat: multi-map support — per-map zone buttons, named map selection, unique_id migration

### DIFF
--- a/custom_components/hass_dyson/button.py
+++ b/custom_components/hass_dyson/button.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from libdyson_rest.models import PersistentMapMeta, ZoneMeta
@@ -24,6 +25,47 @@ _LOGGER = logging.getLogger(__name__)
 # fails during setup.  After the schedule is exhausted the Refresh Zone List
 # button remains available for manual recovery.
 ZONE_DISCOVERY_RETRY_DELAYS: tuple[float, ...] = (60.0, 300.0, 900.0)
+
+
+def _async_migrate_zone_button_unique_ids(
+    hass: HomeAssistant,
+    coordinator: DysonDataUpdateCoordinator,
+    maps: list[PersistentMapMeta],
+) -> None:
+    """Migrate pre-multi-map zone-button unique_ids to the map-qualified form.
+
+    The old ``{serial}_clean_zone_{zone_id}`` unique_id is ambiguous across
+    maps (zone ids restart from 1 per map). The old dedupe created each
+    button for the first map in API order carrying that zone id, so the
+    first map claiming an old unique_id here reproduces exactly which map
+    the entity belonged to — existing entities keep their entity_id and
+    history.
+    """
+    ent_reg = er.async_get(hass)
+    serial = coordinator.serial_number
+    for pmap in maps:
+        for zone in pmap.zones:
+            if not zone.id:
+                continue
+            old_unique_id = f"{serial}_clean_zone_{zone.id}"
+            entity_id = ent_reg.async_get_entity_id("button", DOMAIN, old_unique_id)
+            if entity_id is None:
+                continue
+            new_unique_id = f"{serial}_clean_zone_{pmap.id}_{zone.id}"
+            if ent_reg.async_get_entity_id("button", DOMAIN, new_unique_id):
+                _LOGGER.debug(
+                    "Zone button %s already exists; leaving %s unmigrated",
+                    new_unique_id,
+                    old_unique_id,
+                )
+                continue
+            ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+            _LOGGER.info(
+                "Migrated zone button %s unique_id: %s → %s",
+                entity_id,
+                old_unique_id,
+                new_unique_id,
+            )
 
 
 async def async_setup_entry(
@@ -49,7 +91,7 @@ async def async_setup_entry(
         async_add_entities([DysonReconnectButton(coordinator)], True)
         return
 
-    known_zone_ids: set[str] = set()
+    known_zone_keys: set[tuple[str, str]] = set()
 
     async def _async_discover_zone_buttons() -> int:
         """Fetch map metadata and add buttons for zones not yet seen.
@@ -61,16 +103,22 @@ async def async_setup_entry(
 
         maps = await _fetch_persistent_map_metadata(coordinator)
 
-        # Most robots have a single persistent map; iterate to handle multi-map
-        # setups.
+        _async_migrate_zone_button_unique_ids(hass, coordinator, maps)
+
+        # Zone ids restart from 1 on every map, so dedupe on (map, zone) —
+        # a bare-zone-id key would silently drop every later map's buttons.
+        qualify_names = len(maps) > 1
         new_buttons: list[ButtonEntity] = []
         for pmap in maps:
             for zone in pmap.zones:
-                zone_id = zone.id
-                if not zone_id or zone_id in known_zone_ids:
+                if not zone.id or (pmap.id, zone.id) in known_zone_keys:
                     continue
-                known_zone_ids.add(zone_id)
-                new_buttons.append(DysonZoneCleanButton(coordinator, pmap, zone))
+                known_zone_keys.add((pmap.id, zone.id))
+                new_buttons.append(
+                    DysonZoneCleanButton(
+                        coordinator, pmap, zone, qualify_name=qualify_names
+                    )
+                )
 
         if new_buttons:
             async_add_entities(new_buttons, True)
@@ -187,7 +235,7 @@ class DysonReconnectButton(DysonEntity, ButtonEntity):
 class DysonZoneCleanButton(DysonEntity, ButtonEntity):
     """Per-zone 'Clean this room' button (Vis Nav).
 
-    One entity per zone in the persistent map. Tapping sends a START MQTT
+    One entity per zone per persistent map. Tapping sends a START MQTT
     command with cleaningMode='zoneConfigured' targeting just that zone.
     """
 
@@ -198,31 +246,72 @@ class DysonZoneCleanButton(DysonEntity, ButtonEntity):
         coordinator: DysonDataUpdateCoordinator,
         pmap: PersistentMapMeta,
         zone: ZoneMeta,
+        qualify_name: bool = False,
     ) -> None:
         super().__init__(coordinator)
         self._pmap_id: str = pmap.id
+        self._pmap_name: str = str(pmap.name or pmap.id)
+        self._pmap_zdlud: str | None = pmap.zones_definition_last_updated_date
         self._zone_id: str = zone.id
         self._zone_name: str = str(zone.name or f"Zone {self._zone_id}")
-        # unique_id uses zone_id (stable in MyDyson app even if user renames the zone)
-        self._attr_unique_id = f"{coordinator.serial_number}_clean_zone_{self._zone_id}"
-        self._attr_name = f"Clean {self._zone_name}"
+        # unique_id is map-qualified — zone ids restart from 1 on every map.
+        # Both components are stable in MyDyson even if the user renames them.
+        self._attr_unique_id = (
+            f"{coordinator.serial_number}_clean_zone_{self._pmap_id}_{self._zone_id}"
+        )
+        self._attr_name = (
+            f"Clean {self._zone_name} ({self._pmap_name})"
+            if qualify_name
+            else f"Clean {self._zone_name}"
+        )
         self._attr_icon = _icon_for_zone(zone.icon)
+
+    @property
+    def available(self) -> bool:
+        """Unavailable while the cloud flags a different map as current.
+
+        The v1 API omits isCurrentMap (currency unknown → None), in which
+        case every zone button stays available.
+        """
+        if not super().available:
+            return False
+        from .services import _current_map, _persistent_map_cache
+
+        maps = _persistent_map_cache.get_stale(self.coordinator.serial_number) or []
+        current = _current_map(maps)
+        return current is None or current.id == self._pmap_id
 
     async def async_press(self) -> None:
         if not self.coordinator.device:
             raise HomeAssistantError(
                 f"Device {self.coordinator.serial_number} not available"
             )
+        # Guard against a stale UI: the robot can only clean the map it is on.
+        from .services import _current_map, _persistent_map_cache
+
+        maps = _persistent_map_cache.get_stale(self.coordinator.serial_number) or []
+        current = _current_map(maps)
+        if current is not None and current.id != self._pmap_id:
+            raise HomeAssistantError(
+                f"The robot is currently using map {current.name or current.id!r}; "
+                f"{self._zone_name!r} is on map {self._pmap_name!r}. Move the robot "
+                "to that map and refresh the zone list, then retry."
+            )
         cleaning_programme = {
             "persistentMapId": self._pmap_id,
             "orderedZones": [],
             "unorderedZones": [self._zone_id],
         }
+        # Without zonesDefinitionLastUpdatedDate the device silently
+        # downgrades the START to a global (whole-house) clean.
+        if self._pmap_zdlud:
+            cleaning_programme["zonesDefinitionLastUpdatedDate"] = self._pmap_zdlud
         _LOGGER.info(
-            "Zone-clean button pressed: %s → zone %s (%s)",
+            "Zone-clean button pressed: %s → zone %s (%s, map %s)",
             self.coordinator.serial_number,
             self._zone_id,
             self._zone_name,
+            self._pmap_name,
         )
         try:
             await self.coordinator.device.robot_start_clean(
@@ -242,7 +331,8 @@ class DysonRefreshZonesButton(DysonEntity, ButtonEntity):
     Invalidates the in-process cache used by the start_zone_clean service and
     zone-clean buttons, then adds buttons for any newly-discovered zones
     without requiring a restart.  Renamed zones keep their entity (unique_id
-    is the zone id) and pick up the new name after a Home Assistant restart.
+    is the map + zone id) and pick up the new name after a Home Assistant
+    restart.
     """
 
     coordinator: DysonDataUpdateCoordinator

--- a/custom_components/hass_dyson/button.py
+++ b/custom_components/hass_dyson/button.py
@@ -43,14 +43,21 @@ def _async_migrate_zone_button_unique_ids(
     """
     ent_reg = er.async_get(hass)
     serial = coordinator.serial_number
+    claimed_old_ids: set[str] = set()
     for pmap in maps:
         for zone in pmap.zones:
             if not zone.id:
                 continue
             old_unique_id = f"{serial}_clean_zone_{zone.id}"
+            if old_unique_id in claimed_old_ids:
+                continue
             entity_id = ent_reg.async_get_entity_id("button", DOMAIN, old_unique_id)
             if entity_id is None:
                 continue
+            # The first map (in API order) carrying this zone id owns the old
+            # entity — even when the migration below is skipped, a later map
+            # with a colliding zone id must not claim it.
+            claimed_old_ids.add(old_unique_id)
             new_unique_id = f"{serial}_clean_zone_{pmap.id}_{zone.id}"
             if ent_reg.async_get_entity_id("button", DOMAIN, new_unique_id):
                 _LOGGER.debug(

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -18,7 +18,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "libdyson-rest==0.16.0b1",
+    "libdyson-rest==0.16.0b2",
     "paho-mqtt>=2.1.0"
   ],
   "version": "0.35.1-beta.2"

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -3328,10 +3328,14 @@ class DysonLastCleanSensor(DysonEntity, SensorEntity):
                         self.coordinator.serial_number
                     )
                 if maps:
+                    # Zone ids restart from 1 on every map — resolve names
+                    # from the map the clean ran on, falling back to the
+                    # other maps only for ids it does not carry.
+                    clean_map_id = getattr(clean, "persistent_map_id", None)
                     id_to_name: dict[str, str] = {}
-                    for pmap in maps:
+                    for pmap in sorted(maps, key=lambda m: m.id != clean_map_id):
                         for z in pmap.zones:
-                            id_to_name[z.id] = z.name or z.id
+                            id_to_name.setdefault(z.id, z.name or z.id)
                     zone_names = [id_to_name.get(zid, zid) for zid in zone_ids]
             except Exception:  # noqa: BLE001 — names are a nice-to-have
                 zone_names = []
@@ -3409,6 +3413,7 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
         # stale-cache fallback so we still get friendly names even if the
         # main metadata TTL has expired since the last fetch.
         id_to_name: dict[str, str] = {}
+        names_by_map: dict[str, dict[str, str]] = {}
         try:
             from .services import _persistent_map_cache
 
@@ -3417,8 +3422,10 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
                 maps = _persistent_map_cache.get_stale(self.coordinator.serial_number)
             if maps:
                 for pmap in maps:
-                    for z in pmap.zones:
-                        id_to_name[z.id] = z.name or z.id
+                    per_map = {z.id: (z.name or z.id) for z in pmap.zones}
+                    names_by_map[pmap.id] = per_map
+                    for zid, zname in per_map.items():
+                        id_to_name.setdefault(zid, zname)
         except Exception:  # noqa: BLE001
             pass
 
@@ -3426,6 +3433,11 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
         # Each has .zone_predictions (list[ZonePrediction]) with .dust.total etc.
         predictions: list[dict] = []
         for rcm in data:
+            # Zone ids restart from 1 per map — resolve against this
+            # recommendation's own map when it is in the cache.
+            rcm_names = names_by_map.get(
+                getattr(rcm, "persistent_map_id", None), id_to_name
+            )
             for pred in rcm.zone_predictions:
                 zid = pred.zone_id
                 dust_breakdown = {
@@ -3439,7 +3451,7 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
                 predictions.append(
                     {
                         "zone_id": zid,
-                        "zone_name": id_to_name.get(zid, zid),
+                        "zone_name": rcm_names.get(zid, id_to_name.get(zid, zid)),
                         "total_dust_mg": round(pred.dust.total, 1),
                         "dust_breakdown_mg": dust_breakdown,
                     }

--- a/custom_components/hass_dyson/services.py
+++ b/custom_components/hass_dyson/services.py
@@ -179,13 +179,16 @@ SERVICE_GET_CLOUD_DEVICES_SCHEMA = vol.Schema(
 )
 
 # Zone-cleaning schema: device + list of zone IDs or names. Names are resolved
-# against the persistent-map metadata fetched from the Dyson cloud.
+# against the persistent-map metadata fetched from the Dyson cloud. The
+# optional map (ID or name) disambiguates multi-map robots; when omitted the
+# map is chosen by _select_map (current map → only map → inferred from zones).
 SERVICE_START_ZONE_CLEAN_SCHEMA = vol.Schema(
     {
         vol.Required("device_id"): str,
         vol.Required("zones"): vol.All(
             cv.ensure_list, [vol.All(str, vol.Length(min=1))], vol.Length(min=1)
         ),
+        vol.Optional("map"): vol.All(str, vol.Length(min=1)),
     }
 )
 
@@ -206,6 +209,7 @@ SERVICE_SET_ZONE_BEHAVIOUR_SCHEMA = vol.Schema(
         vol.Required("device_id"): str,
         vol.Required("zone"): vol.All(str, vol.Length(min=1)),
         vol.Required("cleaning_strategy"): vol.In(_ZONE_CLEANING_STRATEGIES),
+        vol.Optional("map"): vol.All(str, vol.Length(min=1)),
     }
 )
 
@@ -673,10 +677,99 @@ async def _fetch_persistent_map_metadata(
     return maps
 
 
+def _zone_in_map(pmap, entry: str):
+    """Resolve a zone ID (exact) or name (case-insensitive) within one map."""
+    return pmap.zone_by_id(entry) or (pmap.zone_by_name(entry) if entry else None)
+
+
+def _current_map(maps: list):
+    """Return the map the cloud flags as current, when exactly one is flagged.
+
+    The v1 (Vis Nav) persistent-map-metadata endpoint has been observed to
+    omit isCurrentMap entirely, in which case every map parses as False and
+    this returns None — callers must treat that as "currency unknown".
+    """
+    current = [m for m in maps if m.is_current_map]
+    return current[0] if len(current) == 1 else None
+
+
+def _maps_summary(maps: list) -> str:
+    """Human-readable map→zones listing for error messages."""
+    return "; ".join(
+        f"{m.name or m.id}: {sorted(str(z.name or z.id) for z in m.zones)}"
+        for m in maps
+    )
+
+
+def _select_map(
+    maps: list,
+    requested: str | None,
+    zone_entries: list[str],
+    *,
+    prefer_current: bool = True,
+):
+    """Pick the persistent map a zone operation should target.
+
+    Precedence (named identification, never positional):
+      1. explicit ``requested`` map — exact ID, else case-insensitive name;
+      2. the only map, when there is just one;
+      3. with ``prefer_current`` (physical cleans, where the robot can only
+         work the map it is on): the map the cloud flags as current
+         (isCurrentMap), then the single map on which every requested zone
+         resolves;
+      4. without it (cloud-only ops like zone behaviours, valid for any
+         map): zone resolution first, currency only as ambiguity tiebreak;
+      5. otherwise raise, listing the maps so the caller can pass ``map``.
+    """
+    if requested:
+        req = requested.strip()
+        by_id = next((m for m in maps if m.id == req), None)
+        if by_id is not None:
+            return by_id
+        matches = [m for m in maps if (m.name or "").lower() == req.lower()]
+        if len(matches) == 1:
+            return matches[0]
+        if matches:
+            raise ServiceValidationError(
+                f"Map name {requested!r} is ambiguous — use a map ID instead: "
+                f"{sorted(m.id for m in matches)}"
+            )
+        raise ServiceValidationError(
+            f"Unknown map {requested!r}. Known maps: "
+            f"{sorted(str(m.name or m.id) for m in maps)}"
+        )
+
+    if len(maps) == 1:
+        return maps[0]
+
+    current = _current_map(maps)
+    if prefer_current and current is not None:
+        return current
+
+    candidates = [
+        m for m in maps if all(_zone_in_map(m, str(e).strip()) for e in zone_entries)
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    if candidates and current in candidates:
+        return current
+    if not candidates:
+        raise ServiceValidationError(
+            f"Zone(s) {zone_entries!r} do not all belong to a single map. "
+            f"Known zones — {_maps_summary(maps)}"
+        )
+    raise ServiceValidationError(
+        f"Zone(s) {zone_entries!r} exist on more than one map "
+        f"({sorted(str(m.name or m.id) for m in candidates)}) — "
+        "pass 'map' to choose one"
+    )
+
+
 async def _handle_start_zone_clean(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle hass_dyson.start_zone_clean — Vis Nav zone-specific cleaning."""
     device_id = call.data["device_id"]
     requested_zones: list[str] = call.data["zones"]
+    requested_map: str | None = call.data.get("map")
 
     coordinator = await _get_coordinator_from_device_id(hass, device_id)
     if not coordinator or not coordinator.device:
@@ -689,26 +782,34 @@ async def _handle_start_zone_clean(hass: HomeAssistant, call: ServiceCall) -> No
             f"No persistent maps returned for {coordinator.serial_number} — "
             "has the robot finished its initial map run?"
         )
-    # Use the first (most-recently-visited) map. Multi-map handling is a v2 concern.
-    pmap = maps[0]
+    pmap = _select_map(maps, requested_map, requested_zones)
     pmap_id = pmap.id
-    zones_by_id = {z.id: z for z in pmap.zones}
-    zones_by_name_lc = {(z.name or "").lower(): z for z in pmap.zones if z.name}
 
     resolved_ids: list[str] = []
     unknown: list[str] = []
     for entry in requested_zones:
         entry_str = str(entry).strip()
-        if entry_str in zones_by_id:
-            resolved_ids.append(entry_str)
-        elif entry_str.lower() in zones_by_name_lc:
-            resolved_ids.append(zones_by_name_lc[entry_str.lower()].id)
+        zone = _zone_in_map(pmap, entry_str)
+        if zone is not None:
+            resolved_ids.append(zone.id)
         else:
             unknown.append(entry_str)
     if unknown:
-        known_names = sorted(z.name for z in pmap.zones if z.name)
+        # Point at the map that does carry the zone, if any — a zone-clean can
+        # only target one map per run.
+        hints = []
+        for entry in unknown:
+            elsewhere = sorted(
+                str(m.name or m.id)
+                for m in maps
+                if m is not pmap and _zone_in_map(m, entry)
+            )
+            if elsewhere:
+                hints.append(f"{entry!r} is on map {elsewhere}")
+        hint = f" ({'; '.join(hints)} — pass 'map' to target it.)" if hints else ""
         raise ServiceValidationError(
-            f"Unknown zone(s) {unknown!r} for map {pmap.name!r}. Known: {known_names}"
+            f"Unknown zone(s) {unknown!r} for map {pmap.name!r}.{hint} "
+            f"Known zones — {_maps_summary(maps)}"
         )
 
     # IMPORTANT: zonesDefinitionLastUpdatedDate must be included for the
@@ -757,6 +858,7 @@ async def _handle_set_zone_behaviour(hass: HomeAssistant, call: ServiceCall) -> 
     device_id = call.data["device_id"]
     zone_in = str(call.data["zone"]).strip()
     cleaning_strategy = call.data["cleaning_strategy"]
+    requested_map: str | None = call.data.get("map")
 
     coordinator = await _get_coordinator_from_device_id(hass, device_id)
     if not coordinator:
@@ -766,19 +868,15 @@ async def _handle_set_zone_behaviour(hass: HomeAssistant, call: ServiceCall) -> 
     maps = await _fetch_persistent_map_metadata(coordinator)
     if not maps:
         raise HomeAssistantError(f"No persistent maps for {coordinator.serial_number}")
-    pmap = maps[0]
+    pmap = _select_map(maps, requested_map, [zone_in], prefer_current=False)
     pmap_id = pmap.id
-    zones_by_id = {z.id: z for z in pmap.zones}
-    zones_by_name_lc = {(z.name or "").lower(): z for z in pmap.zones if z.name}
-    if zone_in in zones_by_id:
-        zone_id = zone_in
-    elif zone_in.lower() in zones_by_name_lc:
-        zone_id = zones_by_name_lc[zone_in.lower()].id
-    else:
+    zone = _zone_in_map(pmap, zone_in)
+    if zone is None:
         raise ServiceValidationError(
-            f"Unknown zone {zone_in!r}. Known: "
-            f"{sorted(z.name for z in pmap.zones if z.name)}"
+            f"Unknown zone {zone_in!r} for map {pmap.name!r}. "
+            f"Known zones — {_maps_summary(maps)}"
         )
+    zone_id = zone.id
 
     from libdyson_rest.exceptions import DysonAPIError, DysonAuthError
 

--- a/custom_components/hass_dyson/services.yaml
+++ b/custom_components/hass_dyson/services.yaml
@@ -140,6 +140,17 @@ start_zone_clean:
       required: true
       selector:
         object:
+    map:
+      name: Map
+      description: >-
+        Persistent map to clean on (name or ID), for robots with more than
+        one map. When omitted, the robot's current map is used if the cloud
+        reports one, then a single stored map, then the map the requested
+        zones uniquely belong to.
+      required: false
+      example: Downstairs
+      selector:
+        text:
 
 set_zone_behaviour:
   name: Set Zone Behaviour (Vis Nav)
@@ -174,3 +185,13 @@ set_zone_behaviour:
             - quick
             - quiet
             - boost
+    map:
+      name: Map
+      description: >-
+        Persistent map the zone belongs to (name or ID), for robots with
+        more than one map. When omitted, the zone is matched across all
+        stored maps and the map is inferred when unambiguous.
+      required: false
+      example: Downstairs
+      selector:
+        text:

--- a/custom_components/hass_dyson/vacuum.py
+++ b/custom_components/hass_dyson/vacuum.py
@@ -60,7 +60,7 @@ from .const import DEVICE_CATEGORY_ROBOT, DOMAIN, ROBOT_STATE_TO_HA_STATE
 from .coordinator import DysonDataUpdateCoordinator, TTLCache
 from .device_utils import mask_serial
 from .entity import DysonEntity
-from .services import _fetch_persistent_map_metadata, _persistent_map_cache
+from .services import _fetch_persistent_map_metadata, _persistent_map_cache, _select_map
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -467,7 +467,8 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
         to their supported_features.
 
         Returns:
-            List of Segment objects, one per zone in the active persistent map.
+            List of Segment objects, one per zone across all stored persistent
+            maps (map-qualified ids when there is more than one map).
             Empty list if no map is available yet.
 
         Raises:
@@ -482,12 +483,26 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
             )
             return []
 
+        # With multiple maps, zone ids collide (they restart from 1 per map),
+        # so segment ids are map-qualified and names carry the map for
+        # disambiguation. Single-map robots keep bare zone ids so existing
+        # area mappings stay valid.
+        multi_map = len(maps) > 1
         segments: list[Segment] = []
         for pmap in maps:
             for zone in pmap.zones:
                 if not zone.id:
                     continue
-                segments.append(Segment(id=zone.id, name=str(zone.name or zone.id)))
+                zone_name = str(zone.name or zone.id)
+                if multi_map:
+                    segments.append(
+                        Segment(
+                            id=f"{pmap.id}:{zone.id}",
+                            name=f"{zone_name} ({pmap.name or pmap.id})",
+                        )
+                    )
+                else:
+                    segments.append(Segment(id=zone.id, name=zone_name))
 
         _LOGGER.debug(
             "Returning %d segments for %s",
@@ -512,6 +527,10 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
         """
         if not self.available or not self.coordinator.device:
             raise HomeAssistantError("Device not available for zone clean command")
+        if not segment_ids:
+            # An empty unorderedZones list risks being honoured as a
+            # whole-house clean — refuse instead.
+            raise HomeAssistantError("No segments specified for zone clean")
 
         maps = await _fetch_persistent_map_metadata(self.coordinator)
         if not maps:
@@ -520,12 +539,49 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
                 "has the robot completed its initial map run?"
             )
 
-        # Use the first (most-recently-visited) map — mirrors services.py behaviour.
-        pmap = maps[0]
+        # Segment ids from async_get_segments are map-qualified
+        # ("{map_id}:{zone_id}") on multi-map robots and bare zone ids on
+        # single-map robots (or pre-multi-map area mappings).
+        by_map: dict[str, list[str]] = {}
+        bare_ids: list[str] = []
+        for seg in segment_ids:
+            map_id, sep, zone_id = str(seg).rpartition(":")
+            if sep:
+                by_map.setdefault(map_id, []).append(zone_id)
+            else:
+                bare_ids.append(str(seg))
+
+        if len(by_map) > 1:
+            raise HomeAssistantError(
+                f"Requested segments span multiple maps "
+                f"({sorted(by_map)}) — the robot can only clean one map per run"
+            )
+        if by_map:
+            map_id, zone_ids = next(iter(by_map.items()))
+            pmap = next((m for m in maps if m.id == map_id), None)
+            if pmap is None:
+                raise HomeAssistantError(
+                    f"Unknown map id {map_id!r} in segment ids — re-map the "
+                    "vacuum segments to areas (the map list has changed)"
+                )
+            zone_ids = zone_ids + bare_ids
+        else:
+            # Selection by named identification: current map when the cloud
+            # flags one, the only map, or the map the zones uniquely match.
+            pmap = _select_map(maps, None, bare_ids)
+            zone_ids = bare_ids
+
+        unknown = [z for z in zone_ids if not any(zz.id == z for zz in pmap.zones)]
+        if unknown:
+            raise HomeAssistantError(
+                f"Zone id(s) {unknown!r} are not on map "
+                f"{pmap.name or pmap.id!r} — re-map the vacuum segments to areas"
+            )
+
         cleaning_programme: dict[str, Any] = {
             "persistentMapId": pmap.id,
             "orderedZones": [],
-            "unorderedZones": segment_ids,
+            "unorderedZones": zone_ids,
         }
         # zonesDefinitionLastUpdatedDate is required for the device to honour
         # a zoneConfigured request; without it the robot silently falls back to
@@ -585,8 +641,16 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
             # Cache miss; skip this cycle.
             return
 
+        # Keys must mirror async_get_segments: map-qualified when multi-map,
+        # bare zone ids otherwise. A pre-multi-map mapping on a robot that
+        # now has two maps therefore differs and raises the repair issue —
+        # which is correct, because its bare-id mapping is ambiguous.
+        multi_map = len(cached_maps) > 1
         current_ids = {
-            zone.id for pmap in cached_maps for zone in pmap.zones if zone.id
+            f"{pmap.id}:{zone.id}" if multi_map else zone.id
+            for pmap in cached_maps
+            for zone in pmap.zones
+            if zone.id
         }
         last_seen_ids = {seg.id for seg in last_seen}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "cryptography>=45.0.7",
-    "libdyson-rest==0.16.0b1",
+    "libdyson-rest==0.16.0b2",
     "homeassistant==2026.7.1",
     "paho-mqtt>=2.1.0",
 ]

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1106,9 +1106,7 @@ class TestZoneButtonUniqueIdMigration:
         self._run(registry, mock_robot_coordinator)
         assert registry.updates == []
 
-    def test_collision_with_existing_new_unique_id_skips(
-        self, mock_robot_coordinator
-    ):
+    def test_collision_with_existing_new_unique_id_skips(self, mock_robot_coordinator):
         """If the map-qualified unique_id already exists, the old one is left."""
         registry = _FakeEntityRegistry(
             {
@@ -1118,6 +1116,4 @@ class TestZoneButtonUniqueIdMigration:
         )
         self._run(registry, mock_robot_coordinator)
         assert registry.updates == []
-        assert (
-            registry.entries["VS9-GB-HJA0000A_clean_zone_1"] == "button.old_hallway"
-        )
+        assert registry.entries["VS9-GB-HJA0000A_clean_zone_1"] == "button.old_hallway"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -14,6 +14,7 @@ from custom_components.hass_dyson.button import (
     DysonReconnectButton,
     DysonRefreshZonesButton,
     DysonZoneCleanButton,
+    _async_migrate_zone_button_unique_ids,
     _icon_for_zone,
     async_setup_entry,
 )
@@ -60,6 +61,20 @@ def mock_hass():
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {}}
     return hass
+
+
+@pytest.fixture(autouse=True)
+def mock_entity_registry():
+    """Stub the entity registry used by the zone-button unique_id migration.
+
+    Defaults to an empty registry (no pre-multi-map entities to migrate).
+    """
+    registry = MagicMock()
+    registry.async_get_entity_id.return_value = None
+    with patch(
+        "custom_components.hass_dyson.button.er.async_get", return_value=registry
+    ):
+        yield registry
 
 
 class TestButtonPlatformSetup:
@@ -442,22 +457,22 @@ class TestButtonPlatformRobotSetup:
         mock_call_later.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_duplicate_zone_ids_deduplicated(
+    async def test_same_zone_id_on_two_maps_creates_two_buttons(
         self, mock_hass, mock_config_entry, mock_robot_coordinator
     ):
-        """Zones with the same ID across maps are deduplicated."""
+        """Zone ids restart per map — each map gets its own button (issue #398)."""
         mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
         add_entities = MagicMock()
         fake_maps = [
             PersistentMapMeta(
                 id="map-1",
-                name=None,
+                name="Upstairs",
                 zones_definition_last_updated_date=None,
                 zones=[ZoneMeta(id="z1", name="Kitchen", icon=None, area=None)],
             ),
             PersistentMapMeta(
                 id="map-2",
-                name=None,
+                name="Downstairs",
                 zones_definition_last_updated_date=None,
                 zones=[ZoneMeta(id="z1", name="Kitchen", icon=None, area=None)],
             ),
@@ -469,9 +484,43 @@ class TestButtonPlatformRobotSetup:
             await async_setup_entry(mock_hass, mock_config_entry, add_entities)
 
         zones = add_entities.call_args_list[1][0][0]
-        # 1 unique zone across both maps
+        assert len(zones) == 2
+        assert all(isinstance(entity, DysonZoneCleanButton) for entity in zones)
+        # Map-qualified unique_ids and names disambiguate the two buttons
+        assert {b._attr_unique_id for b in zones} == {
+            "VS9-GB-HJA0000A_clean_zone_map-1_z1",
+            "VS9-GB-HJA0000A_clean_zone_map-2_z1",
+        }
+        assert {b._attr_name for b in zones} == {
+            "Clean Kitchen (Upstairs)",
+            "Clean Kitchen (Downstairs)",
+        }
+
+    @pytest.mark.asyncio
+    async def test_single_map_names_not_qualified(
+        self, mock_hass, mock_config_entry, mock_robot_coordinator
+    ):
+        """Single-map robots keep the unqualified 'Clean <zone>' names."""
+        mock_hass.data[DOMAIN][mock_config_entry.entry_id] = mock_robot_coordinator
+        add_entities = MagicMock()
+        fake_maps = [
+            PersistentMapMeta(
+                id="map-1",
+                name="Home",
+                zones_definition_last_updated_date=None,
+                zones=[ZoneMeta(id="z1", name="Kitchen", icon=None, area=None)],
+            )
+        ]
+        with patch(
+            "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+            AsyncMock(return_value=fake_maps),
+        ):
+            await async_setup_entry(mock_hass, mock_config_entry, add_entities)
+
+        zones = add_entities.call_args_list[1][0][0]
         assert len(zones) == 1
-        assert isinstance(zones[0], DysonZoneCleanButton)
+        assert zones[0]._attr_name == "Clean Kitchen"
+        assert zones[0]._attr_unique_id == "VS9-GB-HJA0000A_clean_zone_map-1_z1"
 
     @pytest.mark.asyncio
     async def test_non_robot_with_token_no_zone_buttons(
@@ -660,14 +709,27 @@ class TestDysonZoneCleanButton:
         )
 
     def test_init_sets_unique_id(self, mock_robot_coordinator):
-        """unique_id is based on serial + zone id."""
+        """unique_id is map-qualified: serial + map id + zone id."""
         btn = self._make(mock_robot_coordinator)
-        assert btn._attr_unique_id == "VS9-GB-HJA0000A_clean_zone_zone-99"
+        assert btn._attr_unique_id == "VS9-GB-HJA0000A_clean_zone_pmap-1_zone-99"
 
     def test_init_sets_name_from_zone(self, mock_robot_coordinator):
         """Name is 'Clean <zone name>'."""
         btn = self._make(mock_robot_coordinator)
         assert btn._attr_name == "Clean Kitchen"
+
+    def test_init_qualified_name_includes_map(self, mock_robot_coordinator):
+        """qualify_name=True appends the map name (multi-map robots)."""
+        pmap = PersistentMapMeta(
+            id="pmap-2",
+            name="Downstairs",
+            zones_definition_last_updated_date=None,
+            zones=[],
+        )
+        btn = DysonZoneCleanButton(
+            mock_robot_coordinator, pmap, self._FAKE_ZONE, qualify_name=True
+        )
+        assert btn._attr_name == "Clean Kitchen (Downstairs)"
 
     def test_init_zone_name_fallback(self, mock_robot_coordinator):
         """Missing zone name falls back to 'Zone <id>'."""
@@ -722,6 +784,126 @@ class TestDysonZoneCleanButton:
         btn = self._make(mock_robot_coordinator)
         with pytest.raises(HomeAssistantError, match="Failed to start clean"):
             await btn.async_press()
+
+    @pytest.mark.asyncio
+    async def test_async_press_includes_zdlud_when_present(
+        self, mock_robot_coordinator
+    ):
+        """zonesDefinitionLastUpdatedDate from the map is sent in the programme."""
+        mock_robot_coordinator.device.robot_start_clean = AsyncMock()
+        pmap = PersistentMapMeta(
+            id="pmap-1",
+            name=None,
+            zones_definition_last_updated_date="2026-03-01T12:00:00Z",
+            zones=[],
+        )
+        btn = self._make(mock_robot_coordinator, pmap=pmap)
+        await btn.async_press()
+
+        programme = mock_robot_coordinator.device.robot_start_clean.call_args.kwargs[
+            "cleaning_programme"
+        ]
+        assert programme["zonesDefinitionLastUpdatedDate"] == "2026-03-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_async_press_blocked_when_other_map_is_current(
+        self, mock_robot_coordinator
+    ):
+        """Pressing a zone on a non-current map raises instead of sending."""
+        mock_robot_coordinator.device.robot_start_clean = AsyncMock()
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+                is_current_map=True,
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)  # button belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            with pytest.raises(HomeAssistantError, match="currently using map"):
+                await btn.async_press()
+
+        mock_robot_coordinator.device.robot_start_clean.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_press_allowed_when_own_map_is_current(
+        self, mock_robot_coordinator
+    ):
+        """Pressing a zone on the current map sends the command."""
+        mock_robot_coordinator.device.robot_start_clean = AsyncMock()
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+                is_current_map=True,
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            await btn.async_press()
+
+        mock_robot_coordinator.device.robot_start_clean.assert_called_once()
+
+    def test_available_false_when_other_map_is_current(self, mock_robot_coordinator):
+        """Button is unavailable while the cloud flags a different map current."""
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+                is_current_map=True,
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            assert btn.available is False
+
+    def test_available_when_currency_unknown(self, mock_robot_coordinator):
+        """No isCurrentMap flag anywhere (v1 API) → every button stays available."""
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name=None,
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name=None,
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            assert btn.available is True
 
 
 # ---------------------------------------------------------------------------
@@ -827,3 +1009,115 @@ class TestIconForZone:
     def test_empty_string_returns_vacuum(self):
         """Empty string falls back to mdi:vacuum."""
         assert _icon_for_zone("") == "mdi:vacuum"
+
+
+# ---------------------------------------------------------------------------
+# Tests: pre-multi-map unique_id migration
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntityRegistry:
+    """Minimal entity-registry stand-in: unique_id → entity_id mapping."""
+
+    def __init__(self, entries: dict[str, str]):
+        # entries: {unique_id: entity_id}
+        self.entries = dict(entries)
+        self.updates: list[tuple[str, str]] = []
+
+    def async_get_entity_id(self, domain, platform, unique_id):
+        return self.entries.get(unique_id)
+
+    def async_update_entity(self, entity_id, *, new_unique_id):
+        for uid, eid in list(self.entries.items()):
+            if eid == entity_id:
+                del self.entries[uid]
+        self.entries[new_unique_id] = entity_id
+        self.updates.append((entity_id, new_unique_id))
+
+
+class TestZoneButtonUniqueIdMigration:
+    """Test _async_migrate_zone_button_unique_ids."""
+
+    @staticmethod
+    def _maps():
+        return [
+            PersistentMapMeta(
+                id="map-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[
+                    ZoneMeta(id="1", name="Hallway", icon=None, area=None),
+                    ZoneMeta(id="2", name="Office", icon=None, area=None),
+                ],
+            ),
+            PersistentMapMeta(
+                id="map-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[ZoneMeta(id="1", name="Kitchen", icon=None, area=None)],
+            ),
+        ]
+
+    def _run(self, registry, mock_robot_coordinator, maps=None):
+        with patch(
+            "custom_components.hass_dyson.button.er.async_get",
+            return_value=registry,
+        ):
+            _async_migrate_zone_button_unique_ids(
+                MagicMock(), mock_robot_coordinator, maps or self._maps()
+            )
+
+    def test_old_unique_ids_migrate_to_first_map_in_api_order(
+        self, mock_robot_coordinator
+    ):
+        """Old bare-zone-id unique_ids migrate to the first map carrying the id.
+
+        This reproduces which map the pre-multi-map dedupe created the button
+        for, so existing entities keep their entity_id and history.
+        """
+        registry = _FakeEntityRegistry(
+            {
+                "VS9-GB-HJA0000A_clean_zone_1": "button.visnav_clean_hallway",
+                "VS9-GB-HJA0000A_clean_zone_2": "button.visnav_clean_office",
+            }
+        )
+        self._run(registry, mock_robot_coordinator)
+
+        assert sorted(registry.updates) == [
+            ("button.visnav_clean_hallway", "VS9-GB-HJA0000A_clean_zone_map-1_1"),
+            ("button.visnav_clean_office", "VS9-GB-HJA0000A_clean_zone_map-1_2"),
+        ]
+        # The second map's colliding zone id "1" did NOT steal the old entity
+        assert "VS9-GB-HJA0000A_clean_zone_map-2_1" not in registry.entries
+
+    def test_migration_is_idempotent(self, mock_robot_coordinator):
+        """A second run after migration performs no further updates."""
+        registry = _FakeEntityRegistry(
+            {"VS9-GB-HJA0000A_clean_zone_1": "button.visnav_clean_hallway"}
+        )
+        self._run(registry, mock_robot_coordinator)
+        first = list(registry.updates)
+        self._run(registry, mock_robot_coordinator)
+        assert registry.updates == first
+
+    def test_no_old_entities_no_updates(self, mock_robot_coordinator):
+        """Fresh installs (no old-format unique_ids) are untouched."""
+        registry = _FakeEntityRegistry({})
+        self._run(registry, mock_robot_coordinator)
+        assert registry.updates == []
+
+    def test_collision_with_existing_new_unique_id_skips(
+        self, mock_robot_coordinator
+    ):
+        """If the map-qualified unique_id already exists, the old one is left."""
+        registry = _FakeEntityRegistry(
+            {
+                "VS9-GB-HJA0000A_clean_zone_1": "button.old_hallway",
+                "VS9-GB-HJA0000A_clean_zone_map-1_1": "button.new_hallway",
+            }
+        )
+        self._run(registry, mock_robot_coordinator)
+        assert registry.updates == []
+        assert (
+            registry.entries["VS9-GB-HJA0000A_clean_zone_1"] == "button.old_hallway"
+        )

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -905,6 +905,12 @@ class TestDysonZoneCleanButton:
         ):
             assert btn.available is True
 
+    def test_available_false_when_base_unavailable(self, mock_robot_coordinator):
+        """Coordinator/device unavailability wins before any map gating."""
+        mock_robot_coordinator.last_update_success = False
+        btn = self._make(mock_robot_coordinator)
+        assert btn.available is False
+
 
 # ---------------------------------------------------------------------------
 # Tests: DysonRefreshZonesButton
@@ -1117,3 +1123,27 @@ class TestZoneButtonUniqueIdMigration:
         self._run(registry, mock_robot_coordinator)
         assert registry.updates == []
         assert registry.entries["VS9-GB-HJA0000A_clean_zone_1"] == "button.old_hallway"
+
+    def test_zone_without_id_is_skipped(self, mock_robot_coordinator):
+        """A zone with a falsy id never owned an old unique_id — skip it."""
+        maps = [
+            PersistentMapMeta(
+                id="map-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[
+                    ZoneMeta(id="", name="Ghost", icon=None, area=None),
+                    ZoneMeta(id="1", name="Hallway", icon=None, area=None),
+                ],
+            ),
+        ]
+        registry = _FakeEntityRegistry(
+            {
+                "VS9-GB-HJA0000A_clean_zone_": "button.visnav_clean_ghost",
+                "VS9-GB-HJA0000A_clean_zone_1": "button.visnav_clean_hallway",
+            }
+        )
+        self._run(registry, mock_robot_coordinator, maps=maps)
+        assert registry.updates == [
+            ("button.visnav_clean_hallway", "VS9-GB-HJA0000A_clean_zone_map-1_1")
+        ]

--- a/tests/test_sensor_clean_zone_names.py
+++ b/tests/test_sensor_clean_zone_names.py
@@ -1,0 +1,161 @@
+"""Zone-name resolution on the clean-history and recommendation sensors.
+
+Zone ids restart from 1 on every persistent map, so DysonLastCleanSensor and
+DysonRecommendedCleanSensor must resolve names against the map the record
+belongs to before falling back to the other cached maps.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hass_dyson.sensor import (
+    DysonLastCleanSensor,
+    DysonRecommendedCleanSensor,
+)
+
+
+@pytest.fixture
+def mock_robot_coordinator():
+    """Create a mock coordinator for a robot vacuum with cloud token."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "VS9-GB-HJA0000A"
+    coordinator.device_name = "Vis Nav"
+    coordinator.device = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"auth_token": "tok"}
+    return coordinator
+
+
+def _zone(zone_id: str, name: str):
+    return SimpleNamespace(id=zone_id, name=name)
+
+
+def _pmap(pmap_id: str, name: str, zones: list):
+    return SimpleNamespace(id=pmap_id, name=name, zones=zones)
+
+
+def _maps():
+    """Two maps whose zone id '1' collides with different names."""
+    return [
+        _pmap("map-up", "Upstairs", [_zone("1", "Hallway"), _zone("2", "Office")]),
+        _pmap("map-down", "Downstairs", [_zone("1", "Kitchen")]),
+    ]
+
+
+def _map_cache(maps):
+    cache = MagicMock()
+    cache.get.return_value = maps
+    return cache
+
+
+def _clean(zone_ids: list[str], map_id: str | None = None):
+    """Minimal v2 CleanRecord stand-in."""
+    rec = SimpleNamespace(
+        clean_id="clean-1",
+        start_time_epoch=1752480000,
+        clean_duration=42,
+        area_cleaned=18.5,
+        zones=[SimpleNamespace(id=z, is_selected=True) for z in zone_ids],
+        faults=[],
+        is_spot_clean=False,
+        sequence_number=7,
+        start_battery=100,
+        end_battery=61,
+    )
+    if map_id is not None:
+        rec.persistent_map_id = map_id
+    return rec
+
+
+class TestLastCleanZoneNames:
+    """DysonLastCleanSensor resolves zone names per the clean's own map."""
+
+    async def _update(self, coordinator, clean):
+        sensor = DysonLastCleanSensor(coordinator, 0)
+        with (
+            patch(
+                "custom_components.hass_dyson.sensor.fetch_clean_maps",
+                new=AsyncMock(return_value=[clean]),
+            ),
+            patch(
+                "custom_components.hass_dyson.services._persistent_map_cache",
+                _map_cache(_maps()),
+            ),
+        ):
+            await sensor.async_update()
+        return sensor
+
+    @pytest.mark.asyncio
+    async def test_zone_names_prefer_the_cleans_own_map(self, mock_robot_coordinator):
+        """A colliding zone id resolves on the map the clean ran on."""
+        sensor = await self._update(mock_robot_coordinator, _clean(["1"], "map-down"))
+        assert sensor._attr_extra_state_attributes["zone_names"] == ["Kitchen"]
+
+    @pytest.mark.asyncio
+    async def test_foreign_ids_fall_back_to_other_maps(self, mock_robot_coordinator):
+        """Ids the clean's map does not carry resolve from the other maps."""
+        sensor = await self._update(
+            mock_robot_coordinator, _clean(["1", "2"], "map-down")
+        )
+        assert sensor._attr_extra_state_attributes["zone_names"] == [
+            "Kitchen",
+            "Office",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_record_without_map_id_keeps_api_order(self, mock_robot_coordinator):
+        """Pre-multi-map records (no map id) resolve first-map-wins."""
+        sensor = await self._update(mock_robot_coordinator, _clean(["1"]))
+        assert sensor._attr_extra_state_attributes["zone_names"] == ["Hallway"]
+
+
+def _pred(zone_id: str, total: float = 10.0):
+    dust = SimpleNamespace(
+        extra_fine=1.0, fine=2.0, medium=3.0, large=4.0, other=0.5, total=total
+    )
+    return SimpleNamespace(zone_id=zone_id, dust=dust)
+
+
+def _rcm(map_id: str, preds: list):
+    return SimpleNamespace(persistent_map_id=map_id, zone_predictions=preds)
+
+
+class TestRecommendedCleanZoneNames:
+    """DysonRecommendedCleanSensor resolves names per the recommendation's map."""
+
+    async def _update(self, coordinator, rcms):
+        sensor = DysonRecommendedCleanSensor(coordinator)
+        with (
+            patch(
+                "custom_components.hass_dyson.sensor._fetch_recommended_cleans",
+                new=AsyncMock(return_value=rcms),
+            ),
+            patch(
+                "custom_components.hass_dyson.services._persistent_map_cache",
+                _map_cache(_maps()),
+            ),
+        ):
+            await sensor.async_update()
+        return sensor
+
+    @pytest.mark.asyncio
+    async def test_names_resolve_against_the_recommendations_own_map(
+        self, mock_robot_coordinator
+    ):
+        """A colliding zone id names from the recommendation's map."""
+        sensor = await self._update(
+            mock_robot_coordinator, [_rcm("map-down", [_pred("1")])]
+        )
+        assert sensor._attr_native_value == "Kitchen"
+        predictions = sensor._attr_extra_state_attributes["predictions"]
+        assert predictions[0]["zone_name"] == "Kitchen"
+
+    @pytest.mark.asyncio
+    async def test_unknown_map_falls_back_to_global_names(self, mock_robot_coordinator):
+        """A map id missing from the cache falls back to first-map-wins."""
+        sensor = await self._update(
+            mock_robot_coordinator, [_rcm("map-gone", [_pred("1")])]
+        )
+        assert sensor._attr_native_value == "Hallway"

--- a/tests/test_services_zone_clean.py
+++ b/tests/test_services_zone_clean.py
@@ -1,0 +1,294 @@
+"""Tests for multi-map zone-clean map selection and the zone services.
+
+Covers _select_map / _zone_in_map (issue #398: named identification instead
+of maps[0]) and the start_zone_clean / set_zone_behaviour handlers against a
+two-map Vis Nav topology where zone ids restart from 1 on each map and zone
+names repeat across maps.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import ServiceValidationError
+from libdyson_rest.models import PersistentMapMeta, ZoneMeta
+
+from custom_components.hass_dyson.services import (
+    _handle_set_zone_behaviour,
+    _handle_start_zone_clean,
+    _select_map,
+    _zone_in_map,
+)
+
+SERIAL = "VS9-GB-HJA0000A"
+
+
+def _zone(zone_id: str, name: str) -> ZoneMeta:
+    return ZoneMeta(id=zone_id, name=name, icon=None, area=None)
+
+
+def _two_maps(current: str | None = None) -> list[PersistentMapMeta]:
+    """Upstairs/Downstairs with colliding zone ids and duplicate zone names."""
+    return [
+        PersistentMapMeta(
+            id="map-up",
+            name="Upstairs",
+            zones_definition_last_updated_date="2026-03-23T07:02:59Z",
+            zones=[
+                _zone("1", "Hallway"),
+                _zone("2", "Living room"),
+                _zone("3", "Office"),
+            ],
+            is_current_map=current == "map-up",
+        ),
+        PersistentMapMeta(
+            id="map-down",
+            name="Downstairs",
+            zones_definition_last_updated_date="2026-07-10T14:09:15Z",
+            zones=[
+                _zone("1", "Hallway"),
+                _zone("2", "Living room"),
+                _zone("5", "Kitchen"),
+            ],
+            is_current_map=current == "map-down",
+        ),
+    ]
+
+
+class TestZoneInMap:
+    """Test _zone_in_map resolution order."""
+
+    def test_id_match_wins_over_name(self):
+        pmap = _two_maps()[0]
+        assert _zone_in_map(pmap, "2").id == "2"
+
+    def test_name_match_case_insensitive(self):
+        pmap = _two_maps()[0]
+        assert _zone_in_map(pmap, "living ROOM").id == "2"
+
+    def test_no_match_returns_none(self):
+        pmap = _two_maps()[0]
+        assert _zone_in_map(pmap, "Kitchen") is None
+
+
+class TestSelectMap:
+    """Test _select_map precedence (never positional)."""
+
+    def test_explicit_map_id(self):
+        maps = _two_maps()
+        assert _select_map(maps, "map-down", ["1"]).id == "map-down"
+
+    def test_explicit_map_name_case_insensitive(self):
+        maps = _two_maps()
+        assert _select_map(maps, "downstairs", ["1"]).id == "map-down"
+
+    def test_unknown_map_raises_with_known_names(self):
+        maps = _two_maps()
+        with pytest.raises(ServiceValidationError, match="Unknown map 'Basement'"):
+            _select_map(maps, "Basement", ["1"])
+
+    def test_ambiguous_map_name_raises_with_ids(self):
+        maps = _two_maps()
+        maps[1].name = "Upstairs"
+        with pytest.raises(ServiceValidationError, match="ambiguous"):
+            _select_map(maps, "Upstairs", ["1"])
+
+    def test_current_map_preferred(self):
+        maps = _two_maps(current="map-down")
+        assert _select_map(maps, None, ["Hallway"]).id == "map-down"
+
+    def test_current_map_wins_over_zone_inference(self):
+        # "Office" only exists Upstairs, but the robot is on Downstairs —
+        # physical cleans must target the map the robot is on.
+        maps = _two_maps(current="map-down")
+        assert _select_map(maps, None, ["Office"]).id == "map-down"
+
+    def test_single_map_selected(self):
+        maps = [_two_maps()[1]]
+        assert _select_map(maps, None, ["Kitchen"]).id == "map-down"
+
+    def test_zone_inference_unique(self):
+        # No currency info (v1 API omits isCurrentMap): "Kitchen" is
+        # Downstairs-only, so the map is inferred.
+        maps = _two_maps()
+        assert _select_map(maps, None, ["Kitchen"]).id == "map-down"
+
+    def test_zone_inference_no_single_map_raises(self):
+        maps = _two_maps()
+        with pytest.raises(
+            ServiceValidationError, match="do not all belong to a single map"
+        ):
+            _select_map(maps, None, ["Kitchen", "Office"])
+
+    def test_zone_inference_ambiguous_raises(self):
+        maps = _two_maps()
+        with pytest.raises(ServiceValidationError, match="more than one map"):
+            _select_map(maps, None, ["Hallway"])
+
+    def test_prefer_current_false_zone_inference_wins(self):
+        # Cloud-only ops (zone behaviours) are valid for any map — a zone
+        # unique to the non-current map resolves there.
+        maps = _two_maps(current="map-up")
+        pmap = _select_map(maps, None, ["Kitchen"], prefer_current=False)
+        assert pmap.id == "map-down"
+
+    def test_prefer_current_false_ambiguity_falls_back_to_current(self):
+        maps = _two_maps(current="map-up")
+        pmap = _select_map(maps, None, ["Hallway"], prefer_current=False)
+        assert pmap.id == "map-up"
+
+
+def _make_coordinator() -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.serial_number = SERIAL
+    coordinator.device = MagicMock()
+    coordinator.device.robot_start_clean = AsyncMock()
+    return coordinator
+
+
+def _call(data: dict) -> MagicMock:
+    call = MagicMock()
+    call.data = data
+    return call
+
+
+class TestStartZoneCleanService:
+    """Test _handle_start_zone_clean with multi-map metadata."""
+
+    async def _run(self, coordinator, maps, data):
+        with (
+            patch(
+                "custom_components.hass_dyson.services._get_coordinator_from_device_id",
+                AsyncMock(return_value=coordinator),
+            ),
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(return_value=maps),
+            ),
+        ):
+            await _handle_start_zone_clean(MagicMock(), _call(data))
+
+    @pytest.mark.asyncio
+    async def test_zone_unique_to_second_map_is_cleanable(self):
+        """A Downstairs-only zone starts a clean on the Downstairs map."""
+        coordinator = _make_coordinator()
+        await self._run(
+            coordinator,
+            _two_maps(),
+            {"device_id": "dev", "zones": ["Kitchen"]},
+        )
+
+        programme = coordinator.device.robot_start_clean.call_args.kwargs[
+            "cleaning_programme"
+        ]
+        assert programme["persistentMapId"] == "map-down"
+        assert programme["unorderedZones"] == ["5"]
+        assert programme["zonesDefinitionLastUpdatedDate"] == "2026-07-10T14:09:15Z"
+
+    @pytest.mark.asyncio
+    async def test_explicit_map_targets_that_map(self):
+        """map: Downstairs resolves duplicate zone names on that map."""
+        coordinator = _make_coordinator()
+        await self._run(
+            coordinator,
+            _two_maps(),
+            {"device_id": "dev", "zones": ["Living room"], "map": "Downstairs"},
+        )
+
+        programme = coordinator.device.robot_start_clean.call_args.kwargs[
+            "cleaning_programme"
+        ]
+        assert programme["persistentMapId"] == "map-down"
+        assert programme["unorderedZones"] == ["2"]
+
+    @pytest.mark.asyncio
+    async def test_current_map_used_when_flagged(self):
+        """isCurrentMap=true selects the map without an explicit request."""
+        coordinator = _make_coordinator()
+        await self._run(
+            coordinator,
+            _two_maps(current="map-up"),
+            {"device_id": "dev", "zones": ["Hallway", "Office"]},
+        )
+
+        programme = coordinator.device.robot_start_clean.call_args.kwargs[
+            "cleaning_programme"
+        ]
+        assert programme["persistentMapId"] == "map-up"
+        assert programme["unorderedZones"] == ["1", "3"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_zone_error_hints_at_other_map(self):
+        """A zone on the non-selected map is named in the error hint."""
+        coordinator = _make_coordinator()
+        with pytest.raises(ServiceValidationError, match="is on map"):
+            await self._run(
+                coordinator,
+                _two_maps(current="map-up"),
+                {"device_id": "dev", "zones": ["Kitchen"]},
+            )
+        coordinator.device.robot_start_clean.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_zone_name_without_map_or_currency_raises(self):
+        """Ambiguous zone names demand an explicit map when currency is unknown."""
+        coordinator = _make_coordinator()
+        with pytest.raises(ServiceValidationError, match="more than one map"):
+            await self._run(
+                coordinator,
+                _two_maps(),
+                {"device_id": "dev", "zones": ["Living room"]},
+            )
+        coordinator.device.robot_start_clean.assert_not_called()
+
+
+class TestSetZoneBehaviourService:
+    """Test _handle_set_zone_behaviour map selection (cloud-only op)."""
+
+    async def _run(self, coordinator, maps, data):
+        with (
+            patch(
+                "custom_components.hass_dyson.services._get_coordinator_from_device_id",
+                AsyncMock(return_value=coordinator),
+            ),
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(return_value=maps),
+            ),
+        ):
+            await _handle_set_zone_behaviour(MagicMock(), _call(data))
+
+    @staticmethod
+    def _with_cloud_client(coordinator) -> MagicMock:
+        client = MagicMock()
+        client.set_zone_behaviour = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        coordinator.async_cloud_client.return_value = cm
+        return client
+
+    @pytest.mark.asyncio
+    async def test_zone_on_non_current_map_is_settable(self):
+        """Zone behaviours are cloud state — currency must not block them."""
+        coordinator = _make_coordinator()
+        client = self._with_cloud_client(coordinator)
+        await self._run(
+            coordinator,
+            _two_maps(current="map-up"),
+            {"device_id": "dev", "zone": "Kitchen", "cleaning_strategy": "boost"},
+        )
+
+        client.set_zone_behaviour.assert_awaited_once_with(
+            SERIAL, "map-down", "5", "boost"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_zone_without_currency_raises(self):
+        coordinator = _make_coordinator()
+        self._with_cloud_client(coordinator)
+        with pytest.raises(ServiceValidationError, match="more than one map"):
+            await self._run(
+                coordinator,
+                _two_maps(),
+                {"device_id": "dev", "zone": "Hallway", "cleaning_strategy": "auto"},
+            )

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1423,6 +1423,17 @@ class TestCleanAreaMultiMap:
         mock_coordinator_robot.device.robot_start_clean.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_clean_segments_empty_list_raises(self, mock_coordinator_robot):
+        """An empty segment list must not be sent as a whole-house clean."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with pytest.raises(HomeAssistantError, match="No segments specified"):
+            await entity.async_clean_segments([])
+
+        mock_coordinator_robot.device.robot_start_clean.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_clean_segments_bare_id_inferred_across_maps(
         self, mock_coordinator_robot
     ):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -576,13 +576,24 @@ def _make_zone(zone_id: str, zone_name: str, icon: str = "living_room"):
     return z
 
 
-def _make_pmap(pmap_id: str, zones: list, zdlud: str | None = "2026-01-01T00:00:00Z"):
+def _make_pmap(
+    pmap_id: str,
+    zones: list,
+    zdlud: str | None = "2026-01-01T00:00:00Z",
+    name: str = "Ground floor",
+    is_current: bool = False,
+):
     """Create a minimal PersistentMapMeta-like mock."""
     p = MagicMock()
     p.id = pmap_id
-    p.name = "Ground floor"
+    p.name = name
     p.zones = zones
     p.zones_definition_last_updated_date = zdlud
+    p.is_current_map = is_current
+    p.zone_by_id = lambda zid: next((z for z in zones if z.id == zid), None)
+    p.zone_by_name = lambda n: next(
+        (z for z in zones if (z.name or "").lower() == n.lower()), None
+    )
     return p
 
 
@@ -1301,3 +1312,193 @@ class TestFetchCleanMaps:
 
         assert call_count == 1
         assert results[0] == results[1] == [record]
+
+
+# ---------------------------------------------------------------------------
+# Multi-map CLEAN_AREA behaviour (issue #398)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanAreaMultiMap:
+    """Segments and zone cleans on robots with more than one persistent map."""
+
+    @staticmethod
+    def _maps():
+        upstairs = _make_pmap(
+            "map-up",
+            [_make_zone("1", "Hallway"), _make_zone("2", "Office")],
+            zdlud="2026-03-23T07:02:59Z",
+            name="Upstairs",
+        )
+        downstairs = _make_pmap(
+            "map-down",
+            [_make_zone("1", "Hallway"), _make_zone("5", "Kitchen")],
+            zdlud="2026-07-10T14:09:15Z",
+            name="Downstairs",
+        )
+        return [upstairs, downstairs]
+
+    @pytest.mark.asyncio
+    async def test_get_segments_multi_map_qualified(self, mock_coordinator_robot):
+        """Multi-map segments get map-qualified ids and map-suffixed names."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            segments = await entity.async_get_segments()
+
+        assert len(segments) == 4
+        assert segments[0] == Segment(id="map-up:1", name="Hallway (Upstairs)")
+        assert segments[3] == Segment(id="map-down:5", name="Kitchen (Downstairs)")
+
+    @pytest.mark.asyncio
+    async def test_clean_segments_qualified_ids_target_their_map(
+        self, mock_coordinator_robot
+    ):
+        """Qualified segment ids clean on the map they name."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            await entity.async_clean_segments(["map-down:1", "map-down:5"])
+
+        mock_coordinator_robot.device.robot_start_clean.assert_called_once_with(
+            cleaning_mode="zoneConfigured",
+            full_clean_type="immediate",
+            cleaning_programme={
+                "persistentMapId": "map-down",
+                "orderedZones": [],
+                "unorderedZones": ["1", "5"],
+                "zonesDefinitionLastUpdatedDate": "2026-07-10T14:09:15Z",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_clean_segments_spanning_maps_raises(self, mock_coordinator_robot):
+        """One run cannot clean zones from two different maps."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            with pytest.raises(HomeAssistantError, match="span multiple maps"):
+                await entity.async_clean_segments(["map-up:1", "map-down:5"])
+
+        mock_coordinator_robot.device.robot_start_clean.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clean_segments_unknown_map_id_raises(self, mock_coordinator_robot):
+        """A qualified id for a map that no longer exists raises."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            with pytest.raises(HomeAssistantError, match="Unknown map id"):
+                await entity.async_clean_segments(["map-gone:1"])
+
+    @pytest.mark.asyncio
+    async def test_clean_segments_zone_not_on_map_raises(self, mock_coordinator_robot):
+        """Zone ids that are not on the targeted map raise instead of sending."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            with pytest.raises(HomeAssistantError, match="not on map"):
+                await entity.async_clean_segments(["map-up:5"])
+
+        mock_coordinator_robot.device.robot_start_clean.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clean_segments_bare_id_inferred_across_maps(
+        self, mock_coordinator_robot
+    ):
+        """Pre-multi-map bare ids still work when they match exactly one map."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        with patch(
+            "custom_components.hass_dyson.vacuum._fetch_persistent_map_metadata",
+            new=AsyncMock(return_value=self._maps()),
+        ):
+            await entity.async_clean_segments(["5"])
+
+        programme = mock_coordinator_robot.device.robot_start_clean.call_args.kwargs[
+            "cleaning_programme"
+        ]
+        assert programme["persistentMapId"] == "map-down"
+        assert programme["unorderedZones"] == ["5"]
+
+    def test_segment_drift_uses_qualified_ids_when_multi_map(
+        self, mock_coordinator_robot
+    ):
+        """Drift comparison keys mirror the qualified segment ids."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        entity.registry_entry = MagicMock()
+        last_seen = [
+            Segment(id="map-up:1", name="Hallway (Upstairs)"),
+            Segment(id="map-up:2", name="Office (Upstairs)"),
+            Segment(id="map-down:1", name="Hallway (Downstairs)"),
+            Segment(id="map-down:5", name="Kitchen (Downstairs)"),
+        ]
+
+        with (
+            patch.object(entity, "async_write_ha_state"),
+            patch.object(
+                type(entity),
+                "last_seen_segments",
+                new_callable=PropertyMock,
+                return_value=last_seen,
+            ),
+            patch.object(entity, "async_create_segments_issue") as mock_issue,
+            patch(
+                "custom_components.hass_dyson.vacuum._persistent_map_cache"
+            ) as mock_cache,
+        ):
+            mock_cache.get.return_value = self._maps()
+            entity._handle_coordinator_update()
+
+        mock_issue.assert_not_called()
+
+    def test_segment_drift_bare_mapping_on_multi_map_raises_issue(
+        self, mock_coordinator_robot
+    ):
+        """A pre-multi-map bare-id mapping flags re-mapping once a 2nd map exists."""
+        mock_coordinator_robot.config_entry.data = {"auth_token": "tok"}
+        entity = DysonVacuumEntity(mock_coordinator_robot)
+
+        entity.registry_entry = MagicMock()
+        last_seen = [Segment(id="1", name="Hallway"), Segment(id="2", name="Office")]
+
+        with (
+            patch.object(entity, "async_write_ha_state"),
+            patch.object(
+                type(entity),
+                "last_seen_segments",
+                new_callable=PropertyMock,
+                return_value=last_seen,
+            ),
+            patch.object(entity, "async_create_segments_issue") as mock_issue,
+            patch(
+                "custom_components.hass_dyson.vacuum._persistent_map_cache"
+            ) as mock_cache,
+        ):
+            mock_cache.get.return_value = self._maps()
+            entity._handle_coordinator_update()
+
+        mock_issue.assert_called_once()


### PR DESCRIPTION
Fixes #398.

Implements the direction from https://github.com/cmgrayb/hass-dyson/issues/398#issuecomment-4964094463: populate all maps, clean on the current map, no positional `maps[0]` selection, `ent_reg.async_update_entity()` migration, and the stretch goal (buttons for non-current maps report unavailable). Bumps libdyson-rest to 0.16.0b2 for `PersistentMapMeta.is_current_map`.

## What changed

**button.py** — dedupe is now on `(map_id, zone_id)` instead of bare `zone.id`, so every map's zones get buttons. `unique_id` becomes `{serial}_clean_zone_{map_id}_{zone_id}`; existing entities are migrated in place with `er.async_update_entity()` (first map in API order claims each old unique_id — exactly which map the old dedupe created the button for — so entity_ids and history survive). Names gain the map on multi-map robots (`Clean Living room (Downstairs)`). The button's cleaning programme now includes `zonesDefinitionLastUpdatedDate` (services.py documents that its absence silently downgrades the START to a whole-house clean; the button was the only send path missing it). Pressing a zone on a non-current map raises before sending, and `available` returns False while the cloud flags a *different* map current.

**services.py** — the three `maps[0]` sites are gone. A shared `_select_map()` picks by named identification only: explicit `map` field (ID, else case-insensitive name) → the only map → `isCurrentMap` → the single map every requested zone resolves on → `ServiceValidationError` listing the maps. `start_zone_clean` and `set_zone_behaviour` gain an optional `map` field (services.yaml updated). Unknown-zone errors now list zones per map and name the map that does carry the zone ("'Kitchen' is on map ['Downstairs'] — pass 'map' to target it."). `set_zone_behaviour` is cloud-only state, valid for any map, so it resolves by zone first and uses currency only as an ambiguity tiebreak.

**vacuum.py** — `async_get_segments` returns map-qualified segment ids (`{map_id}:{zone_id}`) with map-suffixed names when more than one map exists; single-map robots keep bare zone ids so existing `vacuum.clean_area` area mappings are untouched. `async_clean_segments` parses qualified ids, validates zone membership, refuses cross-map runs and empty segment lists, and resolves legacy bare ids through `_select_map`. The segment-drift repair check uses the same keys, so a pre-multi-map bare-id mapping raises the re-map repair issue once a second map appears (previously the subset-id collision masked it).

**sensor.py** — last-clean and recommended-clean zone-name resolution previously flat-merged all maps' `zone id → name`, mislabelling colliding ids; both now resolve against the map the clean/recommendation belongs to (`persistent_map_id`), falling back to other maps only for ids it doesn't carry.

## Live findings (AU 360 Vis Nav H8W, two maps: Upstairs 10 zones ids 1–10, Downstairs 5 zones ids 1–5)

1. **The v1 `persistent-map-metadata` endpoint never returns `isCurrentMap`** — verified against my live account both docked and mid-clean. Map-level keys are only `id`, `name`, `lastVisited`, `zonesDefinitionLastUpdatedDate`. So on a Vis Nav, 0.16.0b2 parses every map as `is_current_map=False`. All selection paths treat currency as an optional signal and degrade to named identification; the flag will start being honoured automatically on devices/API versions that send it.
2. **There is no MQTT error to handle for a cross-map request.** With the robot docked on the Downstairs map, a `zoneConfigured` START for an Upstairs zone was *accepted*: `INACTIVE_CHARGED → FULL_CLEAN_INITIATED → FULL_CLEAN_DISCOVERING`, `newActiveFaults: []`, robot undocks and wanders trying to localize. No rejection message, no fault at command time — the failure mode is behavioral and delayed. That makes client-side prevention (the press guard plus the availability stretch goal) the only workable handling; both are implemented.
3. **Second-map zone cleans work end-to-end.** Pressing the new `Clean Mud Room (Downstairs)` button produced `FULL_CLEAN_RUNNING` on the Downstairs `persistentMapId` with the state stream showing `zoneStatus: [... {'zoneId': '3', 'cleanStatus': 'CLEAN_IN_PROGRESS'} ...]` — a zone that was unreachable from HA before this change.
4. **Migration verified live:** 10 pre-existing buttons kept their entity_ids (unique_ids rewritten to the map-qualified form, zero old-format leftovers), 5 new Downstairs buttons appeared; 15 total.
5. Observation for a future feature, not in this PR: during zone cleans the robot broadcasts a per-zone `zoneStatus` progress array (`CLEAN_NOT_REQUESTED` / `CLEAN_IN_PROGRESS`) in its state messages — enough to expose live per-zone progress attributes.

## Behavior changes for single-map installs

- Zone-button unique_ids migrate silently (entity_id/history preserved); names, segments, and service behavior are unchanged (`_select_map` short-circuits on the only map).
- Button presses now include `zonesDefinitionLastUpdatedDate`, aligning the button path with the service/vacuum paths per the existing comment about the silent global-clean downgrade.

## Tests

`test_duplicate_zone_ids_deduplicated` asserted the #398 bug as correct and is inverted (`test_same_zone_id_on_two_maps_creates_two_buttons`). New: first service-handler tests for `start_zone_clean`/`set_zone_behaviour`, the `_select_map` precedence chain (including duplicate zone names across maps and a map name colliding with a zone name), unique_id migration (first-map-wins, idempotent, collision-safe), press guard/zdlud/availability, and qualified-segment behavior including bare-id back-compat.

Two pre-existing items noticed while working, deliberately not touched here: `async_remove_services` doesn't unregister the two zone services, and `EVENT_DEVICE_FAULT` in const.py doesn't match the fired event name `dyson_device_fault_detected`. Happy to file/fix separately.
