### PR TITLE
Fix: humidifier bugs (several)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,11 @@
 # TO DO
 
+## Open Items
+
+- [ ] **Refactor fault sensor entity names to use HA translation files** — `DysonFaultSensor` in `binary_sensor.py` sets `_attr_name` via a hardcoded Python dict (`_get_fault_friendly_name()`), bypassing HA's translation system. Each fault code (e.g. `tnke`, `tnkp`, `aqs`) needs a unique `translation_key` wired to `translations/en.json` (and `de.json`, `fr.json`) for proper i18n support. The `FAULT_TRANSLATIONS` attribute messages in `const.py` are a separate concern (used for `extra_state_attributes`) and should also be evaluated for translation.
+
+---
+
 ## ✅ COMPLETED: Tilt Oscillation Support
 
 Implement tilt (vertical) oscillation for devices that expose the `oton`/`otal`/`otau`/`anct`

--- a/custom_components/hass_dyson/binary_sensor.py
+++ b/custom_components/hass_dyson/binary_sensor.py
@@ -311,6 +311,8 @@ class DysonFaultSensor(DysonEntity, BinarySensorEntity):  # type: ignore[misc]
             "sys": "System",
             "brsh": "Brush",
             "bin": "Dustbin",
+            "tnke": "Water Level",
+            "tnkp": "Water Tank Status",
         }
         return fault_names.get(self._fault_code, self._fault_code.upper())
 

--- a/custom_components/hass_dyson/const.py
+++ b/custom_components/hass_dyson/const.py
@@ -379,8 +379,8 @@ FAULT_TRANSLATIONS: Final = {
         "OK": "Water tank level normal",
     },
     "tnkp": {
-        "FAIL": "Water tank problem - check placement",
-        "OK": "Water tank status normal",
+        "FAIL": "Water tank not detected - please check that the tank is seated correctly",
+        "OK": "Water tank detected",
     },
     "cldu": {
         "FAIL": "Humidifier cleaning required",
@@ -598,8 +598,8 @@ CAPABILITY_FAULT_CODES: Final = {
     "Humidifier": [
         "humi",  # Humidity sensor
         "fltr",  # General filter (covers humidifier filter)
-        "tnke",  # Tank empty
-        "tnkp",  # Tank problem
+        "tnke",  # Water tank empty
+        "tnkp",  # Water tank undetected
         "cldu",  # Unknown humidifier fault
         "etwd",  # Unknown humidifier fault
     ],

--- a/custom_components/hass_dyson/coordinator.py
+++ b/custom_components/hass_dyson/coordinator.py
@@ -2139,12 +2139,12 @@ class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         if product_type:
-            # PH model (Purifier/Humidifier) should have virtual Humidifier capability
-            if product_type.startswith("PH"):
+            # PH and 358-series models (Purifier/Humidifier) should have virtual Humidifier capability
+            if product_type.startswith("PH") or product_type.startswith("358"):
                 if "Humidifier" not in capabilities:
                     capabilities.append("Humidifier")
                     _LOGGER.debug(
-                        "Added virtual Humidifier capability for PH model %s",
+                        "Added virtual Humidifier capability for model %s",
                         product_type,
                     )
 

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -2568,13 +2568,13 @@ class DysonDevice:
             return 0
 
     @property
-    def carbon_filter_life(self) -> int:
-        """Return carbon filter life percentage."""
+    def carbon_filter_life(self) -> int | None:
+        """Return carbon filter life percentage, or None if no filter is installed."""
         try:
             product_state = self._state_data.get("product-state", {})
             cflr = self.get_state_value(product_state, "cflr", "0000")
-            if cflr == "INV":  # Invalid/no filter installed
-                return 0
+            if cflr == "INV":  # No filter installed
+                return None
             return int(cflr)
         except (ValueError, TypeError):
             return 0
@@ -3098,6 +3098,32 @@ class DysonDevice:
 
         _LOGGER.debug(
             "Set Breeze oscillation mode for %s",
+            self._log_serial,
+        )
+
+    async def set_find_follow(self, mode: str) -> None:
+        """Set Find+Follow mode.
+
+        Find+Follow uses the device camera to track people in the room and
+        direct airflow toward them.  Only available on devices that report
+        the ``soon`` state key (e.g. Dyson PC3, product type 438).
+
+        Args:
+            mode: One of ``"ON"``, ``"OFF"``, or ``"SCAN"``.
+                  ``SCAN`` triggers an immediate person-scan; the device
+                  returns to ``ON`` automatically after the scan completes.
+
+        Raises:
+            ValueError: If *mode* is not one of the supported values.
+        """
+        if mode not in ("ON", "OFF", "SCAN"):
+            raise ValueError(
+                f"Invalid Find+Follow mode '{mode}'. Must be one of: 'ON', 'OFF', 'SCAN'."
+            )
+        await self.send_command("STATE-SET", {"soon": mode})
+        _LOGGER.debug(
+            "Set Find+Follow mode to '%s' for %s",
+            mode,
             self._log_serial,
         )
 

--- a/custom_components/hass_dyson/device_utils.py
+++ b/custom_components/hass_dyson/device_utils.py
@@ -262,12 +262,12 @@ def extract_capabilities_from_device_info(device_info: Any) -> list[str]:
     # To do: replace product_type.startswith("PH") with a function which determines
     # Humidifier capability from device state.
     if product_type:
-        # PH model (Purifier/Humidifier) should have virtual Humidifier capability
-        if product_type.startswith("PH"):
+        # PH and 358-series models (Purifier/Humidifier) should have virtual Humidifier capability
+        if product_type.startswith("PH") or product_type.startswith("358"):
             if "Humidifier" not in capabilities:
                 capabilities.append("Humidifier")
                 _LOGGER.debug(
-                    "Added virtual Humidifier capability for PH model %s",
+                    "Added virtual Humidifier capability for model %s",
                     product_type,
                 )
 

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -21,5 +21,5 @@
     "libdyson-rest==0.16.0b2",
     "paho-mqtt>=2.1.0"
   ],
-  "version": "0.35.1-beta.2"
+  "version": "0.35.1-beta.4"
 }

--- a/custom_components/hass_dyson/select.py
+++ b/custom_components/hass_dyson/select.py
@@ -790,11 +790,11 @@ class DysonWaterHardnessSelect(DysonEntity, SelectEntity):
             )
 
             # Map device values to display names
-            if water_hardness == "2025":
+            if water_hardness == "0675":
                 self._attr_current_option = "Soft"
             elif water_hardness == "1350":
                 self._attr_current_option = "Medium"
-            elif water_hardness == "0675":
+            elif water_hardness == "2025":
                 self._attr_current_option = "Hard"
             else:
                 _LOGGER.warning(
@@ -815,9 +815,9 @@ class DysonWaterHardnessSelect(DysonEntity, SelectEntity):
 
         # Map display names to device values
         value_map = {
-            "Soft": "2025",
+            "Soft": "0675",
             "Medium": "1350",
-            "Hard": "0675",
+            "Hard": "2025",
         }
 
         if option not in value_map:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-dyson"
-version = "0.35.1-beta.2"
+version = "0.35.1-beta.4"
 description = "Home Assistant Dyson integration focusing on device capabilities and connection information"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_device_coverage_boost.py
+++ b/tests/test_device_coverage_boost.py
@@ -553,6 +553,12 @@ class TestFilterLifeCalculations:
         result = mock_device_basic.carbon_filter_life
         assert result == 100
 
+    def test_carbon_filter_life_inv_returns_none(self, mock_device_basic):
+        """Test carbon filter life returns None when no filter is installed (INV)."""
+        mock_device_basic._state_data = {"product-state": {"cflr": "INV"}}
+        result = mock_device_basic.carbon_filter_life
+        assert result is None
+
     def test_hepa_filter_type_detection(self, mock_device_basic):
         """Test HEPA filter type detection."""
         mock_device_basic._state_data = {"product-state": {"hflt": "HEPA"}}

--- a/tests/test_device_utils_error_coverage.py
+++ b/tests/test_device_utils_error_coverage.py
@@ -287,6 +287,20 @@ class TestExtractCapabilitiesFromDeviceInfoErrorHandling:
         assert "Purifier" in result
         assert "Humidifier" in result
 
+    def test_extract_capabilities_358_model_adds_humidifier(self):
+        """Test extract_capabilities adds Humidifier for 358-series models."""
+        # Arrange
+        device_info = MagicMock()
+        device_info.capabilities = ["Purifier"]
+        device_info.product_type = "358K"
+
+        # Act
+        result = extract_capabilities_from_device_info(device_info)
+
+        # Assert
+        assert "Purifier" in result
+        assert "Humidifier" in result
+
     def test_extract_capabilities_ph_model_does_not_duplicate_humidifier(self):
         """Test extract_capabilities doesn't duplicate Humidifier if already present."""
         # Arrange

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1470,7 +1470,7 @@ class TestDysonWaterHardnessSelect:
     def test_water_hardness_coordinator_update_soft(self, mock_humidifier_coordinator):
         """Test coordinator update with soft water hardness."""
 
-        mock_humidifier_coordinator.device.get_state_value.return_value = "2025"
+        mock_humidifier_coordinator.device.get_state_value.return_value = "0675"
 
         entity = DysonWaterHardnessSelect(mock_humidifier_coordinator)
         entity.hass = MagicMock()
@@ -1482,7 +1482,7 @@ class TestDysonWaterHardnessSelect:
     def test_water_hardness_coordinator_update_hard(self, mock_humidifier_coordinator):
         """Test coordinator update with hard water hardness."""
 
-        mock_humidifier_coordinator.device.get_state_value.return_value = "0675"
+        mock_humidifier_coordinator.device.get_state_value.return_value = "2025"
 
         entity = DysonWaterHardnessSelect(mock_humidifier_coordinator)
         entity.hass = MagicMock()

--- a/tests/test_select_coverage_boost.py
+++ b/tests/test_select_coverage_boost.py
@@ -236,8 +236,8 @@ class TestWaterHardnessSelect:
     """Test DysonWaterHardnessSelect entity."""
 
     def test_handle_update_soft(self, mock_coordinator):
-        """Test coordinator update with Soft (2025) water hardness."""
-        mock_coordinator.device.get_state_value = Mock(return_value="2025")
+        """Test coordinator update with Soft (0675) water hardness."""
+        mock_coordinator.device.get_state_value = Mock(return_value="0675")
 
         entity = DysonWaterHardnessSelect(mock_coordinator)
         entity.async_write_ha_state = MagicMock()
@@ -264,8 +264,8 @@ class TestWaterHardnessSelect:
         assert entity._attr_current_option == "Medium"
 
     def test_handle_update_hard(self, mock_coordinator):
-        """Test coordinator update with Hard (0675) water hardness."""
-        mock_coordinator.device.get_state_value = Mock(return_value="0675")
+        """Test coordinator update with Hard (2025) water hardness."""
+        mock_coordinator.device.get_state_value = Mock(return_value="2025")
 
         entity = DysonWaterHardnessSelect(mock_coordinator)
         entity.async_write_ha_state = MagicMock()


### PR DESCRIPTION
fix: carbon filter life sensor will no longer populate if INV (invalid) is returned
fix: water hardness will now read and set the same value
fix: loosened the detection logic for humidifiers to catch devices which do not report the expected PH prefix