### PR TITLE
feat: Current Map sensor — MQTT-derived map tracking, per-zone progress, and cross-map gating (#402)

### DIFF
--- a/custom_components/hass_dyson/button.py
+++ b/custom_components/hass_dyson/button.py
@@ -275,17 +275,19 @@ class DysonZoneCleanButton(DysonEntity, ButtonEntity):
 
     @property
     def available(self) -> bool:
-        """Unavailable while the cloud flags a different map as current.
+        """Unavailable while the robot is known to be on a different map.
 
-        The v1 API omits isCurrentMap (currency unknown → None), in which
-        case every zone button stays available.
+        The signal is the robot's MQTT-reported map (announced during every
+        clean), falling back to the cloud isCurrentMap flag. When neither is
+        available (e.g. a freshly restarted Vis Nav on its dock — the v1 API
+        omits isCurrentMap) every zone button stays available.
         """
         if not super().available:
             return False
-        from .services import _current_map, _persistent_map_cache
+        from .services import _effective_current_map, _persistent_map_cache
 
         maps = _persistent_map_cache.get_stale(self.coordinator.serial_number) or []
-        current = _current_map(maps)
+        current = _effective_current_map(maps, self.coordinator)
         return current is None or current.id == self._pmap_id
 
     async def async_press(self) -> None:
@@ -294,10 +296,10 @@ class DysonZoneCleanButton(DysonEntity, ButtonEntity):
                 f"Device {self.coordinator.serial_number} not available"
             )
         # Guard against a stale UI: the robot can only clean the map it is on.
-        from .services import _current_map, _persistent_map_cache
+        from .services import _effective_current_map, _persistent_map_cache
 
         maps = _persistent_map_cache.get_stale(self.coordinator.serial_number) or []
-        current = _current_map(maps)
+        current = _effective_current_map(maps, self.coordinator)
         if current is not None and current.id != self._pmap_id:
             raise HomeAssistantError(
                 f"The robot is currently using map {current.name or current.id!r}; "

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -1771,6 +1771,18 @@ class DysonDevice:
         if "product-state" not in self._state_data:
             self._state_data["product-state"] = {}
         self._state_data["product-state"].update(normalized_product_state)
+
+        # Robot vacuums report the active persistent map and per-zone
+        # progress at the top level of state messages during cleans; retain
+        # the latest values so the current-map sensor and cross-map zone
+        # guards can read them (CURRENT-STATE merges whole payloads above,
+        # but STATE-CHANGE arrives first when a clean starts).
+        for key in ("persistentMapId", "zoneStatus"):
+            if key in data:
+                self._state_data[key] = data[key]
+        programme = data.get("cleaningProgramme")
+        if isinstance(programme, dict) and programme.get("persistentMapId"):
+            self._state_data["persistentMapId"] = programme["persistentMapId"]
         _LOGGER.debug("State change for %s", self._log_serial)
 
     def _notify_callbacks(self, topic: str, data: dict[str, Any]) -> None:
@@ -2730,6 +2742,28 @@ class DysonDevice:
                 "Failed to get robot clean ID for %s: %s", self._log_serial, e
             )
             return None
+
+    @property
+    def robot_current_map_id(self) -> str | None:
+        """Return the persistent map the robot last reported operating on.
+
+        Sourced from the MQTT state stream (present during cleans, retained
+        afterwards). None until the robot has reported a map this session —
+        the 360 Vis Nav does not include it while idle on the dock.
+        """
+        value = self._state_data.get("persistentMapId")
+        return str(value) if value else None
+
+    @property
+    def robot_zone_status(self) -> list | None:
+        """Return the robot's per-zone clean progress, if reported.
+
+        List of ``{"zoneId": str, "cleanStatus": str}`` dicts from the MQTT
+        state stream during zone cleans (e.g. CLEAN_IN_PROGRESS /
+        CLEAN_NOT_REQUESTED), retained after the clean ends.
+        """
+        value = self._state_data.get("zoneStatus")
+        return value if isinstance(value, list) else None
 
     def _get_command_timestamp(self) -> str:
         """Get formatted timestamp for MQTT commands."""

--- a/custom_components/hass_dyson/manifest.json
+++ b/custom_components/hass_dyson/manifest.json
@@ -18,7 +18,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "libdyson-rest==0.16.0b2",
+    "libdyson-rest==0.16.0b3",
     "paho-mqtt>=2.1.0"
   ],
   "version": "0.35.1-beta.2"

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -3481,7 +3481,9 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
       2. ``cloud`` — the isCurrentMap flag from persistent-map metadata
          (set by v2/Spot+Clean devices; the Vis Nav v1 endpoint omits it);
       3. ``restored`` — the last known value from before a restart;
-      4. ``clean_history`` — the map of the most recent cloud clean record.
+      4. ``last_visited`` — the map with the newest lastVisited timestamp
+         in the persistent-map metadata (v1 payloads include it);
+      5. ``clean_history`` — the map of the most recent cloud clean record.
 
     During zone cleans the robot also streams per-zone progress, surfaced
     as the ``zone_status`` attribute.
@@ -3548,6 +3550,15 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
             pmap = by_id.get(self._restored_map_id or "")
             name = pmap.name if pmap else self._restored_name
             return self._restored_map_id, name, "restored"
+
+        # Restricted to maps that carry lastVisited (and none is flagged
+        # is_current_map here), find_current_map just picks the newest.
+        visited = [m for m in maps if m.last_visited]
+        if visited:
+            from libdyson_rest.models import find_current_map
+
+            pmap = find_current_map(visited)
+            return pmap.id, pmap.name, "last_visited"
 
         serial = self.coordinator.serial_number
         records = _clean_maps_cache.get(serial) or _clean_maps_cache.get_stale(serial)

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -3490,7 +3490,6 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
     """
 
     coordinator: DysonDataUpdateCoordinator
-    _attr_should_poll = True
 
     def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
@@ -3499,6 +3498,12 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
         self._attr_icon = "mdi:map-marker-path"
         self._restored_map_id: str | None = None
         self._restored_name: str | None = None
+
+    @property
+    def should_poll(self) -> bool:
+        # _attr_should_poll is inert on CoordinatorEntity subclasses (#408);
+        # the explicit override keeps the cache-warming async_update polling.
+        return True
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -67,8 +67,10 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     _PM_SENSOR_UNAVAILABLE_STATES,
@@ -80,7 +82,7 @@ from .const import (
 from .coordinator import DysonDataUpdateCoordinator, TTLCache
 from .device_utils import mask_serial
 from .entity import DysonEntity
-from .vacuum import fetch_clean_maps
+from .vacuum import _clean_maps_cache, fetch_clean_maps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1461,6 +1463,7 @@ async def async_setup_entry(  # noqa: C901
                 for i in range(5):
                     entities.append(DysonLastCleanSensor(coordinator, slot=i))
                 entities.append(DysonRecommendedCleanSensor(coordinator))
+                entities.append(DysonCurrentMapSensor(coordinator))
 
         # Cloud-fetched purifier sensors (outdoor AQI, daily history,
         # MyDyson scheduled events). Only for ec-category devices (air
@@ -3467,6 +3470,126 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
             "top_zone_dust_mg": (predictions[0]["total_dust_mg"] if predictions else 0),
             "predictions": predictions,
         }
+
+
+class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
+    """Which persistent map a multi-map robot is currently using.
+
+    Source priority (exposed via the ``source`` attribute):
+      1. ``robot`` — the persistentMapId the robot itself announced over
+         MQTT (present in every clean's state stream, retained afterwards);
+      2. ``cloud`` — the isCurrentMap flag from persistent-map metadata
+         (set by v2/Spot+Clean devices; the Vis Nav v1 endpoint omits it);
+      3. ``restored`` — the last known value from before a restart;
+      4. ``clean_history`` — the map of the most recent cloud clean record.
+
+    During zone cleans the robot also streams per-zone progress, surfaced
+    as the ``zone_status`` attribute.
+    """
+
+    coordinator: DysonDataUpdateCoordinator
+    _attr_should_poll = True
+
+    def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.serial_number}_current_map"
+        self._attr_name = "Current Map"
+        self._attr_icon = "mdi:map-marker-path"
+        self._restored_map_id: str | None = None
+        self._restored_name: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        if last and last.state not in ("unknown", "unavailable"):
+            self._restored_name = last.state
+            self._restored_map_id = last.attributes.get("map_id")
+
+    async def async_update(self) -> None:
+        """Warm the metadata and clean-history caches (both TTL-cached)."""
+        from .services import _fetch_persistent_map_metadata
+
+        try:
+            await _fetch_persistent_map_metadata(self.coordinator)
+        except HomeAssistantError:
+            pass
+        try:
+            await fetch_clean_maps(self.coordinator)
+        except HomeAssistantError:
+            pass
+
+    def _cached_maps(self) -> list:
+        from .services import _persistent_map_cache
+
+        serial = self.coordinator.serial_number
+        maps = _persistent_map_cache.get(serial)
+        if maps is None:
+            maps = _persistent_map_cache.get_stale(serial)
+        return maps or []
+
+    def _resolve(self) -> tuple[str | None, str | None, str | None]:
+        """Return (map_id, map_name, source) from the best available signal."""
+        from .services import _current_map
+
+        maps = self._cached_maps()
+        by_id = {m.id: m for m in maps}
+
+        device = self.coordinator.device
+        map_id = getattr(device, "robot_current_map_id", None) if device else None
+        if map_id:
+            pmap = by_id.get(map_id)
+            return map_id, (pmap.name if pmap else None), "robot"
+
+        cloud = _current_map(maps)
+        if cloud is not None:
+            return cloud.id, cloud.name, "cloud"
+
+        if self._restored_map_id or self._restored_name:
+            pmap = by_id.get(self._restored_map_id or "")
+            name = pmap.name if pmap else self._restored_name
+            return self._restored_map_id, name, "restored"
+
+        serial = self.coordinator.serial_number
+        records = _clean_maps_cache.get(serial) or _clean_maps_cache.get_stale(serial)
+        for record in records or []:
+            record_map_id = getattr(record, "persistent_map_id", None)
+            if record_map_id:
+                pmap = by_id.get(record_map_id)
+                return record_map_id, (pmap.name if pmap else None), "clean_history"
+
+        return None, None, None
+
+    @property
+    def native_value(self) -> str | None:
+        map_id, name, _source = self._resolve()
+        if name is None and map_id is None:
+            return None
+        return str(name or map_id)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        map_id, _name, source = self._resolve()
+        attrs: dict[str, Any] = {"map_id": map_id, "source": source}
+
+        pmap = next((m for m in self._cached_maps() if m.id == map_id), None)
+        if pmap is not None:
+            attrs["zones"] = [str(z.name or z.id) for z in pmap.zones]
+
+        # Per-zone progress is only meaningful while a clean is running —
+        # the robot retains the last zoneStatus after docking.
+        device = self.coordinator.device
+        zone_status = getattr(device, "robot_zone_status", None) if device else None
+        robot_state = str(getattr(device, "robot_state", "") or "")
+        if zone_status and robot_state.startswith(("FULL_CLEAN", "MAPPING")):
+            names = {z.id: str(z.name or z.id) for z in pmap.zones} if pmap else {}
+            attrs["zone_status"] = {
+                names.get(entry.get("zoneId"), entry.get("zoneId")): entry.get(
+                    "cleanStatus"
+                )
+                for entry in zone_status
+                if isinstance(entry, dict)
+            }
+        return attrs
 
 
 # ============================================================================

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -3551,8 +3551,9 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
             name = pmap.name if pmap else self._restored_name
             return self._restored_map_id, name, "restored"
 
-        # Restricted to maps that carry lastVisited (and none is flagged
-        # is_current_map here), find_current_map just picks the newest.
+        # Restricted to maps that carry lastVisited so find_current_map
+        # cannot raise; with no cloud flag set (the v1 norm) it returns
+        # the newest-visited map.
         visited = [m for m in maps if m.last_visited]
         if visited:
             from libdyson_rest.models import find_current_map
@@ -3579,6 +3580,8 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        from .services import _ACTIVE_ROBOT_STATE_PREFIXES
+
         map_id, _name, source = self._resolve()
         attrs: dict[str, Any] = {"map_id": map_id, "source": source}
 
@@ -3591,7 +3594,7 @@ class DysonCurrentMapSensor(DysonEntity, RestoreEntity, SensorEntity):
         device = self.coordinator.device
         zone_status = getattr(device, "robot_zone_status", None) if device else None
         robot_state = str(getattr(device, "robot_state", "") or "")
-        if zone_status and robot_state.startswith(("FULL_CLEAN", "MAPPING")):
+        if zone_status and robot_state.startswith(_ACTIVE_ROBOT_STATE_PREFIXES):
             names = {z.id: str(z.name or z.id) for z in pmap.zones} if pmap else {}
             attrs["zone_status"] = {
                 names.get(entry.get("zoneId"), entry.get("zoneId")): entry.get(

--- a/custom_components/hass_dyson/services.py
+++ b/custom_components/hass_dyson/services.py
@@ -693,18 +693,27 @@ def _current_map(maps: list):
     return current[0] if len(current) == 1 else None
 
 
+# Robot states in which the MQTT-reported map is live truth. Docked/idle the
+# robot stops reporting a map, and HA cannot tell whether it has been carried
+# to another floor — so a retained value must not gate anything.
+_ACTIVE_ROBOT_STATE_PREFIXES = ("FULL_CLEAN", "MAPPING")
+
+
 def _effective_current_map(maps: list, coordinator=None):
     """Return the map the robot is on, from the best available signal.
 
-    The robot's own MQTT state stream is authoritative when it has reported
-    a map this session (it announces the persistentMapId during every
-    clean); otherwise fall back to the cloud isCurrentMap flag, which v2
-    (Spot+Clean) devices set but the Vis Nav v1 endpoint never sends.
-    Returns None when neither signal is available.
+    The robot's MQTT stream is authoritative only while it is actually
+    working a map (it stops reporting once docked, so a retained value
+    cannot see the robot being carried to another floor); otherwise fall
+    back to the cloud isCurrentMap flag, which v2 (Spot+Clean) devices
+    update on self-detected relocation — the Vis Nav v1 endpoint never
+    sends it. Returns None when neither signal is available; callers
+    treat that as "currency unknown" and fail open rather than block.
     """
     device = getattr(coordinator, "device", None) if coordinator else None
     map_id = getattr(device, "robot_current_map_id", None)
-    if map_id:
+    robot_state = str(getattr(device, "robot_state", "") or "")
+    if map_id and robot_state.startswith(_ACTIVE_ROBOT_STATE_PREFIXES):
         match = next((m for m in maps if m.id == map_id), None)
         if match is not None:
             return match

--- a/custom_components/hass_dyson/services.py
+++ b/custom_components/hass_dyson/services.py
@@ -693,6 +693,24 @@ def _current_map(maps: list):
     return current[0] if len(current) == 1 else None
 
 
+def _effective_current_map(maps: list, coordinator=None):
+    """Return the map the robot is on, from the best available signal.
+
+    The robot's own MQTT state stream is authoritative when it has reported
+    a map this session (it announces the persistentMapId during every
+    clean); otherwise fall back to the cloud isCurrentMap flag, which v2
+    (Spot+Clean) devices set but the Vis Nav v1 endpoint never sends.
+    Returns None when neither signal is available.
+    """
+    device = getattr(coordinator, "device", None) if coordinator else None
+    map_id = getattr(device, "robot_current_map_id", None)
+    if map_id:
+        match = next((m for m in maps if m.id == map_id), None)
+        if match is not None:
+            return match
+    return _current_map(maps)
+
+
 def _maps_summary(maps: list) -> str:
     """Human-readable map→zones listing for error messages."""
     return "; ".join(
@@ -707,6 +725,7 @@ def _select_map(
     zone_entries: list[str],
     *,
     prefer_current: bool = True,
+    current_map=None,
 ):
     """Pick the persistent map a zone operation should target.
 
@@ -714,9 +733,10 @@ def _select_map(
       1. explicit ``requested`` map — exact ID, else case-insensitive name;
       2. the only map, when there is just one;
       3. with ``prefer_current`` (physical cleans, where the robot can only
-         work the map it is on): the map the cloud flags as current
-         (isCurrentMap), then the single map on which every requested zone
-         resolves;
+         work the map it is on): the current map — ``current_map`` when the
+         caller resolved one (e.g. from the robot's MQTT state via
+         ``_effective_current_map``), else the cloud isCurrentMap flag —
+         then the single map on which every requested zone resolves;
       4. without it (cloud-only ops like zone behaviours, valid for any
          map): zone resolution first, currency only as ambiguity tiebreak;
       5. otherwise raise, listing the maps so the caller can pass ``map``.
@@ -742,7 +762,7 @@ def _select_map(
     if len(maps) == 1:
         return maps[0]
 
-    current = _current_map(maps)
+    current = current_map if current_map is not None else _current_map(maps)
     if prefer_current and current is not None:
         return current
 
@@ -782,7 +802,12 @@ async def _handle_start_zone_clean(hass: HomeAssistant, call: ServiceCall) -> No
             f"No persistent maps returned for {coordinator.serial_number} — "
             "has the robot finished its initial map run?"
         )
-    pmap = _select_map(maps, requested_map, requested_zones)
+    pmap = _select_map(
+        maps,
+        requested_map,
+        requested_zones,
+        current_map=_effective_current_map(maps, coordinator),
+    )
     pmap_id = pmap.id
 
     resolved_ids: list[str] = []
@@ -868,7 +893,13 @@ async def _handle_set_zone_behaviour(hass: HomeAssistant, call: ServiceCall) -> 
     maps = await _fetch_persistent_map_metadata(coordinator)
     if not maps:
         raise HomeAssistantError(f"No persistent maps for {coordinator.serial_number}")
-    pmap = _select_map(maps, requested_map, [zone_in], prefer_current=False)
+    pmap = _select_map(
+        maps,
+        requested_map,
+        [zone_in],
+        prefer_current=False,
+        current_map=_effective_current_map(maps, coordinator),
+    )
     pmap_id = pmap.id
     zone = _zone_in_map(pmap, zone_in)
     if zone is None:

--- a/custom_components/hass_dyson/vacuum.py
+++ b/custom_components/hass_dyson/vacuum.py
@@ -60,7 +60,12 @@ from .const import DEVICE_CATEGORY_ROBOT, DOMAIN, ROBOT_STATE_TO_HA_STATE
 from .coordinator import DysonDataUpdateCoordinator, TTLCache
 from .device_utils import mask_serial
 from .entity import DysonEntity
-from .services import _fetch_persistent_map_metadata, _persistent_map_cache, _select_map
+from .services import (
+    _effective_current_map,
+    _fetch_persistent_map_metadata,
+    _persistent_map_cache,
+    _select_map,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -566,9 +571,15 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
                 )
             zone_ids = zone_ids + bare_ids
         else:
-            # Selection by named identification: current map when the cloud
-            # flags one, the only map, or the map the zones uniquely match.
-            pmap = _select_map(maps, None, bare_ids)
+            # Selection by named identification: the map the robot is on
+            # (MQTT-reported or cloud-flagged), the only map, or the map the
+            # zones uniquely match.
+            pmap = _select_map(
+                maps,
+                None,
+                bare_ids,
+                current_map=_effective_current_map(maps, self.coordinator),
+            )
             zone_ids = bare_ids
 
         unknown = [z for z in zone_ids if not any(zz.id == z for zz in pmap.zones)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "cryptography>=45.0.7",
-    "libdyson-rest==0.16.0b2",
+    "libdyson-rest==0.16.0b3",
     "homeassistant==2026.7.2",
     "paho-mqtt>=2.1.0",
 ]

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -907,6 +907,32 @@ class TestDysonZoneCleanButton:
         ):
             assert btn.available is False
 
+    def test_available_true_when_robot_on_own_map(self, mock_robot_coordinator):
+        """A zone button on the robot's actively-reported map stays available."""
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        mock_robot_coordinator.device.robot_current_map_id = "pmap-1"
+        mock_robot_coordinator.device.robot_state = "FULL_CLEAN_RUNNING"
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            assert btn.available is True
+
     @pytest.mark.asyncio
     async def test_async_press_blocked_when_robot_reports_other_map(
         self, mock_robot_coordinator

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -900,6 +900,7 @@ class TestDysonZoneCleanButton:
         cache = MagicMock()
         cache.get_stale.return_value = cached_maps
         mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        mock_robot_coordinator.device.robot_state = "FULL_CLEAN_RUNNING"
         btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
         with patch(
             "custom_components.hass_dyson.services._persistent_map_cache", cache
@@ -913,6 +914,7 @@ class TestDysonZoneCleanButton:
         """MQTT-reported map blocks a cross-map press even without cloud flags."""
         mock_robot_coordinator.device.robot_start_clean = AsyncMock()
         mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        mock_robot_coordinator.device.robot_state = "FULL_CLEAN_RUNNING"
         cached_maps = [
             PersistentMapMeta(
                 id="pmap-1",
@@ -937,6 +939,64 @@ class TestDysonZoneCleanButton:
                 await btn.async_press()
 
         mock_robot_coordinator.device.robot_start_clean.assert_not_called()
+
+    def test_available_when_docked_despite_retained_map(self, mock_robot_coordinator):
+        """Docked robot: the retained MQTT map must not gate availability."""
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        mock_robot_coordinator.device.robot_state = "INACTIVE_CHARGED"
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            assert btn.available is True
+
+    @pytest.mark.asyncio
+    async def test_async_press_allowed_when_docked_despite_retained_map(
+        self, mock_robot_coordinator
+    ):
+        """Docked robot: a retained other-map value must not block a press."""
+        mock_robot_coordinator.device.robot_start_clean = AsyncMock()
+        mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        mock_robot_coordinator.device.robot_state = "INACTIVE_CHARGED"
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            await btn.async_press()
+
+        mock_robot_coordinator.device.robot_start_clean.assert_called_once()
 
     def test_available_when_currency_unknown(self, mock_robot_coordinator):
         """No isCurrentMap flag anywhere (v1 API) → every button stays available."""

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -881,9 +881,7 @@ class TestDysonZoneCleanButton:
         ):
             assert btn.available is False
 
-    def test_available_false_when_robot_reports_other_map(
-        self, mock_robot_coordinator
-    ):
+    def test_available_false_when_robot_reports_other_map(self, mock_robot_coordinator):
         """The robot's own MQTT-reported map gates availability (no cloud flag)."""
         cached_maps = [
             PersistentMapMeta(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -881,6 +881,65 @@ class TestDysonZoneCleanButton:
         ):
             assert btn.available is False
 
+    def test_available_false_when_robot_reports_other_map(
+        self, mock_robot_coordinator
+    ):
+        """The robot's own MQTT-reported map gates availability (no cloud flag)."""
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            assert btn.available is False
+
+    @pytest.mark.asyncio
+    async def test_async_press_blocked_when_robot_reports_other_map(
+        self, mock_robot_coordinator
+    ):
+        """MQTT-reported map blocks a cross-map press even without cloud flags."""
+        mock_robot_coordinator.device.robot_start_clean = AsyncMock()
+        mock_robot_coordinator.device.robot_current_map_id = "pmap-2"
+        cached_maps = [
+            PersistentMapMeta(
+                id="pmap-1",
+                name="Upstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+            PersistentMapMeta(
+                id="pmap-2",
+                name="Downstairs",
+                zones_definition_last_updated_date=None,
+                zones=[],
+            ),
+        ]
+        cache = MagicMock()
+        cache.get_stale.return_value = cached_maps
+        btn = self._make(mock_robot_coordinator)  # belongs to pmap-1
+        with patch(
+            "custom_components.hass_dyson.services._persistent_map_cache", cache
+        ):
+            with pytest.raises(HomeAssistantError, match="currently using map"):
+                await btn.async_press()
+
+        mock_robot_coordinator.device.robot_start_clean.assert_not_called()
+
     def test_available_when_currency_unknown(self, mock_robot_coordinator):
         """No isCurrentMap flag anywhere (v1 API) → every button stays available."""
         cached_maps = [

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -190,6 +190,10 @@ class TestCurrentMapSensor:
         assert sensor._attr_unique_id == f"{SERIAL}_current_map"
         assert sensor._attr_name == "Current Map"
 
+    def test_should_poll_is_effective(self):
+        """_attr_should_poll is inert on CoordinatorEntity subclasses (#408)."""
+        assert self._sensor().should_poll is True
+
     def test_robot_source_wins(self):
         sensor = self._sensor(device_map_id="map-down")
         p1, p2 = self._patched(_maps(current="map-up"))

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from libdyson_rest.models import PersistentMapMeta, ZoneMeta
 
 from custom_components.hass_dyson.device import DysonDevice
+from custom_components.hass_dyson.entity import DysonEntity
 from custom_components.hass_dyson.sensor import DysonCurrentMapSensor
 from custom_components.hass_dyson.services import _effective_current_map
 
@@ -299,6 +300,20 @@ class TestCurrentMapSensor:
         p1, p2 = self._patched([])
         with p1, p2:
             assert sensor.native_value == "map-mystery"
+            attrs = sensor.extra_state_attributes
+        assert attrs["map_id"] == "map-mystery"
+        assert "zones" not in attrs
+
+    def test_clean_history_skips_records_without_map_id(self):
+        sensor = self._sensor(device_map_id=None)
+        empty = MagicMock()
+        empty.persistent_map_id = None
+        record = MagicMock()
+        record.persistent_map_id = "map-up"
+        p1, p2 = self._patched(_maps(), records=[empty, record])
+        with p1, p2:
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "clean_history"
 
     def test_zone_status_attribute_while_cleaning(self):
         sensor = self._sensor(
@@ -344,6 +359,45 @@ class TestCurrentMapSensor:
         fetch_cleans.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_added_to_hass_restores_state(self):
+        """A valid previous state seeds the restored map name and id."""
+        sensor = self._sensor()
+        last = MagicMock()
+        last.state = "Downstairs"
+        last.attributes = {"map_id": "map-down"}
+        with (
+            patch.object(DysonEntity, "async_added_to_hass", AsyncMock()),
+            patch.object(sensor, "async_get_last_state", AsyncMock(return_value=last)),
+        ):
+            await sensor.async_added_to_hass()
+        assert sensor._restored_name == "Downstairs"
+        assert sensor._restored_map_id == "map-down"
+
+    @pytest.mark.asyncio
+    async def test_added_to_hass_ignores_unknown_state(self):
+        sensor = self._sensor()
+        last = MagicMock()
+        last.state = "unknown"
+        with (
+            patch.object(DysonEntity, "async_added_to_hass", AsyncMock()),
+            patch.object(sensor, "async_get_last_state", AsyncMock(return_value=last)),
+        ):
+            await sensor.async_added_to_hass()
+        assert sensor._restored_name is None
+        assert sensor._restored_map_id is None
+
+    @pytest.mark.asyncio
+    async def test_added_to_hass_without_previous_state(self):
+        sensor = self._sensor()
+        with (
+            patch.object(DysonEntity, "async_added_to_hass", AsyncMock()),
+            patch.object(sensor, "async_get_last_state", AsyncMock(return_value=None)),
+        ):
+            await sensor.async_added_to_hass()
+        assert sensor._restored_name is None
+        assert sensor._restored_map_id is None
+
+    @pytest.mark.asyncio
     async def test_async_update_metadata_failure_still_warms_clean_history(self):
         """A cloud failure on one cache must not stop warming the other."""
         sensor = self._sensor()
@@ -359,3 +413,20 @@ class TestCurrentMapSensor:
         ):
             await sensor.async_update()
         fetch_cleans.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_update_clean_history_failure_is_swallowed(self):
+        """A clean-history fetch failure must not escape async_update."""
+        sensor = self._sensor()
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(return_value=[]),
+            ) as fetch_maps,
+            patch(
+                "custom_components.hass_dyson.sensor.fetch_clean_maps",
+                AsyncMock(side_effect=HomeAssistantError("cloud down")),
+            ),
+        ):
+            await sensor.async_update()
+        fetch_maps.assert_awaited_once()

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -111,10 +111,13 @@ class TestEffectiveCurrentMap:
     """Test the robot-first, cloud-fallback current-map resolution."""
 
     @staticmethod
-    def _coordinator(device_map_id) -> MagicMock:
+    def _coordinator(
+        device_map_id, robot_state: str = "FULL_CLEAN_RUNNING"
+    ) -> MagicMock:
         coordinator = MagicMock()
         coordinator.device = MagicMock()
         coordinator.device.robot_current_map_id = device_map_id
+        coordinator.device.robot_state = robot_state
         return coordinator
 
     def test_robot_reported_map_wins_over_cloud_flag(self):
@@ -129,6 +132,17 @@ class TestEffectiveCurrentMap:
 
     def test_no_signals_returns_none(self):
         coordinator = self._coordinator(None)
+        assert _effective_current_map(_maps(), coordinator) is None
+
+    def test_docked_retained_map_defers_to_cloud_flag(self):
+        """Docked, the retained MQTT map is stale — the cloud flag wins."""
+        maps = _maps(current="map-up")
+        coordinator = self._coordinator("map-down", robot_state="INACTIVE_CHARGED")
+        assert _effective_current_map(maps, coordinator).id == "map-up"
+
+    def test_docked_retained_map_without_cloud_flag_is_unknown(self):
+        """Docked with no cloud flag: currency is unknown, not the stale map."""
+        coordinator = self._coordinator("map-down", robot_state="INACTIVE_CHARGED")
         assert _effective_current_map(_maps(), coordinator) is None
 
     def test_no_coordinator_uses_cloud_flag(self):

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -22,7 +22,10 @@ def _zone(zone_id: str, name: str) -> ZoneMeta:
     return ZoneMeta(id=zone_id, name=name, icon=None, area=None)
 
 
-def _maps(current: str | None = None) -> list[PersistentMapMeta]:
+def _maps(
+    current: str | None = None, visited: dict[str, str] | None = None
+) -> list[PersistentMapMeta]:
+    visited = visited or {}
     return [
         PersistentMapMeta(
             id="map-up",
@@ -30,6 +33,7 @@ def _maps(current: str | None = None) -> list[PersistentMapMeta]:
             zones_definition_last_updated_date=None,
             zones=[_zone("1", "Hallway"), _zone("2", "Office")],
             is_current_map=current == "map-up",
+            last_visited=visited.get("map-up"),
         ),
         PersistentMapMeta(
             id="map-down",
@@ -37,6 +41,7 @@ def _maps(current: str | None = None) -> list[PersistentMapMeta]:
             zones_definition_last_updated_date=None,
             zones=[_zone("1", "Hallway"), _zone("3", "Mud Room")],
             is_current_map=current == "map-down",
+            last_visited=visited.get("map-down"),
         ),
     ]
 
@@ -190,7 +195,42 @@ class TestCurrentMapSensor:
             assert sensor.native_value == "Downstairs"
             assert sensor.extra_state_attributes["source"] == "restored"
 
+    def test_last_visited_newest_wins(self):
+        sensor = self._sensor(device_map_id=None)
+        p1, p2 = self._patched(
+            _maps(
+                visited={
+                    "map-up": "2026-07-10T09:12:00Z",
+                    "map-down": "2026-07-11T16:39:57.525Z",
+                }
+            )
+        )
+        with p1, p2:
+            assert sensor.native_value == "Downstairs"
+            assert sensor.extra_state_attributes["source"] == "last_visited"
+
+    def test_restored_outranks_last_visited(self):
+        sensor = self._sensor(device_map_id=None)
+        sensor._restored_map_id = "map-up"
+        sensor._restored_name = "Upstairs"
+        p1, p2 = self._patched(_maps(visited={"map-down": "2026-07-11T16:39:57Z"}))
+        with p1, p2:
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "restored"
+
+    def test_last_visited_outranks_clean_history(self):
+        sensor = self._sensor(device_map_id=None)
+        record = MagicMock()
+        record.persistent_map_id = "map-up"
+        p1, p2 = self._patched(
+            _maps(visited={"map-down": "2026-07-11T16:39:57Z"}), records=[record]
+        )
+        with p1, p2:
+            assert sensor.native_value == "Downstairs"
+            assert sensor.extra_state_attributes["source"] == "last_visited"
+
     def test_clean_history_fallback(self):
+        """All-None lastVisited must skip the last_visited source entirely."""
         sensor = self._sensor(device_map_id=None)
         record = MagicMock()
         record.persistent_map_id = "map-up"

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -9,6 +9,7 @@ v2/Spot+Clean devices set the cloud flag instead. Both signals are covered.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from libdyson_rest.models import PersistentMapMeta, ZoneMeta
 
 from custom_components.hass_dyson.device import DysonDevice
@@ -145,6 +146,11 @@ class TestEffectiveCurrentMap:
         coordinator = self._coordinator("map-down", robot_state="INACTIVE_CHARGED")
         assert _effective_current_map(_maps(), coordinator) is None
 
+    def test_mapping_state_counts_as_active(self):
+        """First-run mapping announces the map being built — trust it."""
+        coordinator = self._coordinator("map-down", robot_state="MAPPING_RUNNING")
+        assert _effective_current_map(_maps(), coordinator).id == "map-down"
+
     def test_no_coordinator_uses_cloud_flag(self):
         assert _effective_current_map(_maps(current="map-down")).id == "map-down"
 
@@ -201,13 +207,23 @@ class TestCurrentMapSensor:
             assert sensor.extra_state_attributes["source"] == "cloud"
 
     def test_restored_source(self):
+        """A restored id resolves to the LIVE metadata name, not the persisted one."""
         sensor = self._sensor(device_map_id=None)
         sensor._restored_map_id = "map-down"
-        sensor._restored_name = "Downstairs"
+        sensor._restored_name = "Stale Persisted Name"
         p1, p2 = self._patched(_maps())
         with p1, p2:
             assert sensor.native_value == "Downstairs"
             assert sensor.extra_state_attributes["source"] == "restored"
+
+    def test_cloud_outranks_restored(self):
+        sensor = self._sensor(device_map_id=None)
+        sensor._restored_map_id = "map-down"
+        sensor._restored_name = "Downstairs"
+        p1, p2 = self._patched(_maps(current="map-up"))
+        with p1, p2:
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "cloud"
 
     def test_last_visited_newest_wins(self):
         sensor = self._sensor(device_map_id=None)
@@ -259,6 +275,25 @@ class TestCurrentMapSensor:
         with p1, p2:
             assert sensor.native_value is None
 
+    def test_stale_metadata_cache_still_resolves(self):
+        """A fresh-cache miss must fall back to the stale metadata copy."""
+        sensor = self._sensor(device_map_id=None)
+        pmap_cache = MagicMock()
+        pmap_cache.get.return_value = None
+        pmap_cache.get_stale.return_value = _maps(current="map-up")
+        clean_cache = MagicMock()
+        clean_cache.get.return_value = None
+        clean_cache.get_stale.return_value = None
+        with (
+            patch(
+                "custom_components.hass_dyson.services._persistent_map_cache",
+                pmap_cache,
+            ),
+            patch("custom_components.hass_dyson.sensor._clean_maps_cache", clean_cache),
+        ):
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "cloud"
+
     def test_robot_map_id_without_metadata_shows_id(self):
         sensor = self._sensor(device_map_id="map-mystery")
         p1, p2 = self._patched([])
@@ -306,4 +341,21 @@ class TestCurrentMapSensor:
         ):
             await sensor.async_update()
         fetch_maps.assert_awaited_once()
+        fetch_cleans.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_update_metadata_failure_still_warms_clean_history(self):
+        """A cloud failure on one cache must not stop warming the other."""
+        sensor = self._sensor()
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(side_effect=HomeAssistantError("cloud down")),
+            ),
+            patch(
+                "custom_components.hass_dyson.sensor.fetch_clean_maps",
+                AsyncMock(return_value=[]),
+            ) as fetch_cleans,
+        ):
+            await sensor.async_update()
         fetch_cleans.assert_awaited_once()

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -1,0 +1,257 @@
+"""Tests for current-map tracking: device MQTT harvest, _effective_current_map,
+and the Current Map sensor.
+
+The 360 Vis Nav announces the persistentMapId (and per-zone progress) in its
+MQTT state stream during cleans but never via the cloud isCurrentMap flag;
+v2/Spot+Clean devices set the cloud flag instead. Both signals are covered.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from libdyson_rest.models import PersistentMapMeta, ZoneMeta
+
+from custom_components.hass_dyson.device import DysonDevice
+from custom_components.hass_dyson.sensor import DysonCurrentMapSensor
+from custom_components.hass_dyson.services import _effective_current_map
+
+SERIAL = "VS9-GB-HJA0000A"
+
+
+def _zone(zone_id: str, name: str) -> ZoneMeta:
+    return ZoneMeta(id=zone_id, name=name, icon=None, area=None)
+
+
+def _maps(current: str | None = None) -> list[PersistentMapMeta]:
+    return [
+        PersistentMapMeta(
+            id="map-up",
+            name="Upstairs",
+            zones_definition_last_updated_date=None,
+            zones=[_zone("1", "Hallway"), _zone("2", "Office")],
+            is_current_map=current == "map-up",
+        ),
+        PersistentMapMeta(
+            id="map-down",
+            name="Downstairs",
+            zones_definition_last_updated_date=None,
+            zones=[_zone("1", "Hallway"), _zone("3", "Mud Room")],
+            is_current_map=current == "map-down",
+        ),
+    ]
+
+
+def _bare_device() -> DysonDevice:
+    device = object.__new__(DysonDevice)
+    device._state_data = {}
+    device._log_serial = "TEST-SERIAL"
+    device._message_callbacks = []
+    return device
+
+
+class TestDeviceMapHarvest:
+    """Test that state messages populate robot_current_map_id/zone_status."""
+
+    def test_state_change_harvests_programme_map_id(self):
+        device = _bare_device()
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "oldstate": "INACTIVE_CHARGED",
+                "newstate": "FULL_CLEAN_INITIATED",
+                "cleaningProgramme": {
+                    "persistentMapId": "map-down",
+                    "orderedZones": [],
+                    "unorderedZones": ["3"],
+                },
+            }
+        )
+        assert device.robot_current_map_id == "map-down"
+
+    def test_state_change_harvests_top_level_map_and_zone_status(self):
+        device = _bare_device()
+        zone_status = [
+            {"zoneId": "1", "cleanStatus": "CLEAN_NOT_REQUESTED"},
+            {"zoneId": "3", "cleanStatus": "CLEAN_IN_PROGRESS"},
+        ]
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "newstate": "FULL_CLEAN_RUNNING",
+                "persistentMapId": "map-down",
+                "zoneStatus": zone_status,
+            }
+        )
+        assert device.robot_current_map_id == "map-down"
+        assert device.robot_zone_status == zone_status
+
+    def test_idle_current_state_retains_last_map(self):
+        """A docked CURRENT-STATE (no map fields) must not clear the map."""
+        device = _bare_device()
+        device._handle_state_change(
+            {"msg": "STATE-CHANGE", "persistentMapId": "map-down"}
+        )
+        device._handle_current_state(
+            {"msg": "CURRENT-STATE", "state": "INACTIVE_CHARGED"}, "topic"
+        )
+        assert device.robot_current_map_id == "map-down"
+
+    def test_unset_returns_none(self):
+        device = _bare_device()
+        assert device.robot_current_map_id is None
+        assert device.robot_zone_status is None
+
+
+class TestEffectiveCurrentMap:
+    """Test the robot-first, cloud-fallback current-map resolution."""
+
+    @staticmethod
+    def _coordinator(device_map_id) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.device = MagicMock()
+        coordinator.device.robot_current_map_id = device_map_id
+        return coordinator
+
+    def test_robot_reported_map_wins_over_cloud_flag(self):
+        maps = _maps(current="map-up")
+        coordinator = self._coordinator("map-down")
+        assert _effective_current_map(maps, coordinator).id == "map-down"
+
+    def test_unmatched_robot_id_falls_back_to_cloud(self):
+        maps = _maps(current="map-up")
+        coordinator = self._coordinator("map-gone")
+        assert _effective_current_map(maps, coordinator).id == "map-up"
+
+    def test_no_signals_returns_none(self):
+        coordinator = self._coordinator(None)
+        assert _effective_current_map(_maps(), coordinator) is None
+
+    def test_no_coordinator_uses_cloud_flag(self):
+        assert _effective_current_map(_maps(current="map-down")).id == "map-down"
+
+
+class TestCurrentMapSensor:
+    """Test DysonCurrentMapSensor source priority and attributes."""
+
+    @staticmethod
+    def _sensor(device_map_id=None, robot_state="INACTIVE_CHARGED"):
+        coordinator = MagicMock()
+        coordinator.serial_number = SERIAL
+        coordinator.device = MagicMock()
+        coordinator.device.robot_current_map_id = device_map_id
+        coordinator.device.robot_zone_status = None
+        coordinator.device.robot_state = robot_state
+        return DysonCurrentMapSensor(coordinator)
+
+    @staticmethod
+    def _patched(maps, records=None):
+        pmap_cache = MagicMock()
+        pmap_cache.get.return_value = maps
+        pmap_cache.get_stale.return_value = maps
+        clean_cache = MagicMock()
+        clean_cache.get.return_value = records
+        clean_cache.get_stale.return_value = records
+        return (
+            patch(
+                "custom_components.hass_dyson.services._persistent_map_cache",
+                pmap_cache,
+            ),
+            patch(
+                "custom_components.hass_dyson.sensor._clean_maps_cache", clean_cache
+            ),
+        )
+
+    def test_unique_id_and_name(self):
+        sensor = self._sensor()
+        assert sensor._attr_unique_id == f"{SERIAL}_current_map"
+        assert sensor._attr_name == "Current Map"
+
+    def test_robot_source_wins(self):
+        sensor = self._sensor(device_map_id="map-down")
+        p1, p2 = self._patched(_maps(current="map-up"))
+        with p1, p2:
+            assert sensor.native_value == "Downstairs"
+            attrs = sensor.extra_state_attributes
+        assert attrs["source"] == "robot"
+        assert attrs["map_id"] == "map-down"
+        assert attrs["zones"] == ["Hallway", "Mud Room"]
+
+    def test_cloud_source(self):
+        sensor = self._sensor(device_map_id=None)
+        p1, p2 = self._patched(_maps(current="map-up"))
+        with p1, p2:
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "cloud"
+
+    def test_restored_source(self):
+        sensor = self._sensor(device_map_id=None)
+        sensor._restored_map_id = "map-down"
+        sensor._restored_name = "Downstairs"
+        p1, p2 = self._patched(_maps())
+        with p1, p2:
+            assert sensor.native_value == "Downstairs"
+            assert sensor.extra_state_attributes["source"] == "restored"
+
+    def test_clean_history_fallback(self):
+        sensor = self._sensor(device_map_id=None)
+        record = MagicMock()
+        record.persistent_map_id = "map-up"
+        p1, p2 = self._patched(_maps(), records=[record])
+        with p1, p2:
+            assert sensor.native_value == "Upstairs"
+            assert sensor.extra_state_attributes["source"] == "clean_history"
+
+    def test_no_signal_is_unknown(self):
+        sensor = self._sensor(device_map_id=None)
+        p1, p2 = self._patched(_maps(), records=[])
+        with p1, p2:
+            assert sensor.native_value is None
+
+    def test_robot_map_id_without_metadata_shows_id(self):
+        sensor = self._sensor(device_map_id="map-mystery")
+        p1, p2 = self._patched([])
+        with p1, p2:
+            assert sensor.native_value == "map-mystery"
+
+    def test_zone_status_attribute_while_cleaning(self):
+        sensor = self._sensor(
+            device_map_id="map-down", robot_state="FULL_CLEAN_RUNNING"
+        )
+        sensor.coordinator.device.robot_zone_status = [
+            {"zoneId": "1", "cleanStatus": "CLEAN_NOT_REQUESTED"},
+            {"zoneId": "3", "cleanStatus": "CLEAN_IN_PROGRESS"},
+        ]
+        p1, p2 = self._patched(_maps())
+        with p1, p2:
+            attrs = sensor.extra_state_attributes
+        assert attrs["zone_status"] == {
+            "Hallway": "CLEAN_NOT_REQUESTED",
+            "Mud Room": "CLEAN_IN_PROGRESS",
+        }
+
+    def test_zone_status_hidden_when_docked(self):
+        sensor = self._sensor(device_map_id="map-down", robot_state="INACTIVE_CHARGED")
+        sensor.coordinator.device.robot_zone_status = [
+            {"zoneId": "3", "cleanStatus": "CLEAN_IN_PROGRESS"}
+        ]
+        p1, p2 = self._patched(_maps())
+        with p1, p2:
+            attrs = sensor.extra_state_attributes
+        assert "zone_status" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_async_update_warms_both_caches(self):
+        sensor = self._sensor()
+        with (
+            patch(
+                "custom_components.hass_dyson.services._fetch_persistent_map_metadata",
+                AsyncMock(return_value=[]),
+            ) as fetch_maps,
+            patch(
+                "custom_components.hass_dyson.sensor.fetch_clean_maps",
+                AsyncMock(return_value=[]),
+            ) as fetch_cleans,
+        ):
+            await sensor.async_update()
+        fetch_maps.assert_awaited_once()
+        fetch_cleans.assert_awaited_once()

--- a/tests/test_current_map.py
+++ b/tests/test_current_map.py
@@ -156,9 +156,7 @@ class TestCurrentMapSensor:
                 "custom_components.hass_dyson.services._persistent_map_cache",
                 pmap_cache,
             ),
-            patch(
-                "custom_components.hass_dyson.sensor._clean_maps_cache", clean_cache
-            ),
+            patch("custom_components.hass_dyson.sensor._clean_maps_cache", clean_cache),
         )
 
     def test_unique_id_and_name(self):

--- a/tests/test_services_zone_clean.py
+++ b/tests/test_services_zone_clean.py
@@ -96,6 +96,13 @@ class TestSelectMap:
         maps = _two_maps(current="map-down")
         assert _select_map(maps, None, ["Hallway"]).id == "map-down"
 
+    def test_caller_resolved_current_map_wins(self):
+        # The robot's MQTT-derived map (resolved by the caller via
+        # _effective_current_map) short-circuits without any cloud flag.
+        maps = _two_maps()
+        pmap = _select_map(maps, None, ["Hallway"], current_map=maps[1])
+        assert pmap.id == "map-down"
+
     def test_current_map_wins_over_zone_inference(self):
         # "Office" only exists Upstairs, but the robot is on Downstairs —
         # physical cleans must target the map the robot is on.


### PR DESCRIPTION
Implements #402.

With #401 merged, multi-map robots are fully reachable — but HA still can't answer "which map is the robot using right now?", and the wrong-map experiment from #401 showed why that matters: a `zoneConfigured` START for the wrong map is silently accepted, and the robot undocks and hangs in `FULL_CLEAN_DISCOVERING` (failed localization).

## What this adds

**`sensor.<device>_current_map`** — state is the current map's name, resolved from the best available signal and exposed via a `source` attribute:

| Priority | Source | Signal |
|---|---|---|
| 1 | `robot` | `persistentMapId` the robot announces in its own MQTT state stream during every clean (retained after docking) |
| 2 | `cloud` | `isCurrentMap` from persistent-map metadata — set by v2/Spot+Clean devices; the Vis Nav's v1 endpoint omits it (verified docked *and* mid-clean) |
| 3 | `restored` | last known value across HA restarts (`RestoreEntity`) |
| 4 | `last_visited` | map with the newest `lastVisited` timestamp in the v1 metadata, via libdyson-rest's `find_current_map` helper |
| 5 | `clean_history` | map of the most recent cloud clean record |

Attributes: `map_id`, `source`, the resolved map's `zones`, and — only while a clean is running — `zone_status`, mapping zone names to the live `CLEAN_IN_PROGRESS`/`CLEAN_NOT_REQUESTED` progress the robot streams.

**Device layer** (`device.py`): STATE-CHANGE handling retains top-level `persistentMapId`/`zoneStatus` (and `cleaningProgramme.persistentMapId`); idle CURRENT-STATE payloads don't clear them; exposed as `robot_current_map_id`/`robot_zone_status`.

**Gating integration**: the #401 zone-button availability/press guard and `_select_map` consume the same resolved signal (robot-reported first, cloud flag fallback), so "gray out the other floor's buttons" activates on Vis Nav too — degrading to always-available when no signal exists (fresh restart, idle robot).

One important asymmetry surfaced in live testing: for **gating**, the MQTT-reported map is only treated as truth while the robot is actively working a map (`FULL_CLEAN*`/`MAPPING*` states). The Vis Nav stops reporting `persistentMapId` once docked, so a retained value can't see the robot being carried to another floor — an unattended clean otherwise left the other floor's ten zone buttons unavailable *permanently* (the dock lives on one map, and nothing could ever flip the signal back). Docked/idle, gating falls back to the cloud `isCurrentMap` flag — which v2 devices update on self-detected relocation, so this keeps your original stretch-goal semantics there — and fails open when neither signal exists. The *sensor* deliberately keeps reporting the retained map regardless of robot state: sound for display, unsound for blocking.

**Dependency**: bumps `libdyson-rest` to `0.16.0b3` in both `manifest.json` and `pyproject.toml`, picking up `lastVisited` parsing on `PersistentMapMeta` and the `find_current_map` helper (cmgrayb/libdyson-rest#210). The sensor only hands `find_current_map` maps that actually carry the timestamp, so the priority stays exactly as documented and the `DysonMapError` path is unreachable.

## Live testing

Running on my two-map 360 Vis Nav (AU): on a fresh HA restart the sensor resolves the dock's map ("Downstairs") via `clean_history`; the `robot` source takes over within seconds of a clean starting (verified on an unattended clean) and is retained after docking; per-zone progress appears during zone cleans and disappears once docked. The docked-gating regression described above was caught on this device and is covered by the state-window fix plus tests. The `last_visited` source is new in this revision (it needed 0.16.0b3) and is covered by unit tests — on my device it slots between `restored` and `clean_history` exactly as the metadata suggests, since Dyson stamps `lastVisited` on every map.

## Open question (v2 hardware)

I can't verify whether v2 (Spot+Clean / Spot+Scrub) MQTT state messages carry `cleaningProgramme.persistentMapId`/`zoneStatus` the way the Vis Nav's do. The MQTT tracking is written to be purely additive — if a v2 robot never sends these, tracking degrades to the cloud `isCurrentMap` flag, which is authoritative on those models anyway. If you can capture a v2 zone-clean state message, that would confirm — happy to follow up with v2-specific handling once real data exists.

## Gates

- `python -m ruff format --check --diff .` — clean
- `python -m ruff check .` — clean
- `python -m pytest tests/` — **2512 passed, 1 skipped** (pre-PR baseline 2499 + 13 new tests: source priority, gating window, and review-surfaced edges)
