### PR TITLE
fix: make polling effective on the Recommended Clean sensor and both image entities (#408)

### DIFF
--- a/custom_components/hass_dyson/image.py
+++ b/custom_components/hass_dyson/image.py
@@ -768,7 +768,6 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
     """Dust-density heatmap of the most recent clean, rendered as PNG."""
 
     coordinator: DysonDataUpdateCoordinator
-    _attr_should_poll = True
     _attr_content_type = "image/png"
 
     def __init__(
@@ -781,6 +780,11 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
         self._attr_icon = "mdi:map-search"
         self._cached_clean_id: str | None = None
         self._cached_png: bytes | None = None
+
+    @property
+    def should_poll(self) -> bool:
+        # _attr_should_poll is inert on CoordinatorEntity subclasses (#408).
+        return True
 
     async def _build(self) -> bytes | None:
         cleans = await fetch_clean_maps(self.coordinator)
@@ -907,7 +911,6 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
     """
 
     coordinator: DysonDataUpdateCoordinator
-    _attr_should_poll = True
     _attr_content_type = "image/png"
 
     def __init__(
@@ -920,6 +923,11 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
         self._attr_icon = "mdi:floor-plan"
         self._cached_pmap_id: str | None = None
         self._cached_png: bytes | None = None
+
+    @property
+    def should_poll(self) -> bool:
+        # _attr_should_poll is inert on CoordinatorEntity subclasses (#408).
+        return True
 
     async def _build(self) -> bytes | None:
         cleans = await fetch_clean_maps(self.coordinator)

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -3399,13 +3399,17 @@ class DysonRecommendedCleanSensor(DysonEntity, SensorEntity):
     """
 
     coordinator: DysonDataUpdateCoordinator
-    _attr_should_poll = True
     _attr_icon = "mdi:lightbulb-on-outline"
 
     def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_recommended_clean"
         self._attr_name = "Recommended Clean"
+
+    @property
+    def should_poll(self) -> bool:
+        # _attr_should_poll is inert on CoordinatorEntity subclasses (#408).
+        return True
 
     async def async_update(self) -> None:
         data = await _fetch_recommended_cleans(self.coordinator)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1336,7 +1336,7 @@ class TestDysonDustMapImage:
         """Content type is image/png and polling is enabled."""
         entity = self._make_entity(mock_coordinator)
         assert entity._attr_content_type == "image/png"
-        assert entity._attr_should_poll is True
+        assert entity.should_poll is True
 
     def test_init_cache_attrs_are_none(self, mock_coordinator):
         """Cache attributes start as None."""
@@ -1730,7 +1730,7 @@ class TestDysonFloorPlanImage:
         """Content type is image/png and polling is enabled."""
         entity = self._make_entity(mock_coordinator)
         assert entity._attr_content_type == "image/png"
-        assert entity._attr_should_poll is True
+        assert entity.should_poll is True
 
     def test_init_cache_attrs_are_none(self, mock_coordinator):
         """Cache attributes start as None."""

--- a/tests/test_should_poll.py
+++ b/tests/test_should_poll.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #408.
+
+_attr_should_poll = True is inert on CoordinatorEntity subclasses: the
+coordinator base overrides should_poll as a cached_property returning False,
+so polling requires an explicit property override. These assert the override
+is effective on every entity that relies on HA's polling cycle to refresh
+its TTL-cached cloud data (DysonLastCleanSensor is the pre-existing control).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.hass_dyson.image import DysonDustMapImage, DysonFloorPlanImage
+from custom_components.hass_dyson.sensor import (
+    DysonLastCleanSensor,
+    DysonRecommendedCleanSensor,
+)
+
+_PATCH_IMAGE_INIT = patch(
+    "homeassistant.components.image.ImageEntity.__init__", return_value=None
+)
+_PATCH_DYSON_INIT = patch(
+    "custom_components.hass_dyson.image.DysonEntity.__init__", return_value=None
+)
+
+
+def _coordinator() -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.serial_number = "VS9-GB-HJA0000A"
+    coordinator.device_name = "Vis Nav"
+    return coordinator
+
+
+def test_last_clean_sensor_polls():
+    assert DysonLastCleanSensor(_coordinator(), 0).should_poll is True
+
+
+def test_recommended_clean_sensor_polls():
+    assert DysonRecommendedCleanSensor(_coordinator()).should_poll is True
+
+
+def test_dust_map_image_polls():
+    with _PATCH_IMAGE_INIT, _PATCH_DYSON_INIT:
+        entity = DysonDustMapImage(MagicMock(), _coordinator())
+    assert entity.should_poll is True
+
+
+def test_floor_plan_image_polls():
+    with _PATCH_IMAGE_INIT, _PATCH_DYSON_INIT:
+        entity = DysonFloorPlanImage(MagicMock(), _coordinator())
+    assert entity.should_poll is True


### PR DESCRIPTION
Fixes #408.

`_attr_should_poll = True` is inert on `CoordinatorEntity` subclasses — `BaseCoordinatorEntity` overrides `should_poll` as a `cached_property` returning `False`, and the `_attr_*` attribute only feeds `Entity`'s own implementation, which that override shadows. The affected entities populate once at add time (`async_add_entities(entities, True)`) and then freeze; full mechanism and verification in #408.

`DysonLastCleanSensor` already carries the working pattern (explicit `should_poll` property alongside the attribute, since v0.34.0). This PR gives the other three the same override:

| Entity | Before | After |
|---|---|---|
| `DysonRecommendedCleanSensor` | never polls → recommendation frozen at boot | polls; `_fetch_recommended_cleans` 30-min TTL bounds cloud calls |
| `DysonDustMapImage` | never polls → PNG frozen at boot (its `async_update` comment says "Trigger a refresh on HA's polling cycle") | polls; `_map_image_cache` 10-min TTL bounds cloud calls |
| `DysonFloorPlanImage` | never polls → floor plan frozen at boot | polls; `_floor_plan_cache`/`_persist_map_cache` 6-h TTLs bound cloud calls |

The inert `_attr_should_poll = True` lines are replaced by the property so the dead pattern doesn't get copied into new entities. Every fetch path involved is TTL-cached, so the 30-second platform tick is a cache hit except one cloud call per TTL window — the cadence the docstrings already claim.

New `tests/test_should_poll.py` asserts `should_poll is True` on instances of all four entities (Last Clean as the control) — a test shape that would have caught this regression. Two existing image tests asserted the inert attribute itself (`entity._attr_should_poll is True`) — which is how the bug survived the suite — and now assert the effective property instead.

## Gates

- `python -m ruff format --check --diff .` / `python -m ruff check .` — clean
- `python -m pytest tests/` — **2483 passed, 1 skipped** (baseline 2479 + 4 new tests)
