### PR TITLE
fix: stop per-map zone-clean buttons churning availability every clean

### DIFF
--- a/custom_components/hass_dyson/button.py
+++ b/custom_components/hass_dyson/button.py
@@ -418,23 +418,20 @@ class DysonZoneCleanButton(DysonEntity, ButtonEntity):
 
     @property
     def available(self) -> bool:
-        """Unavailable while the robot is known to be on a different map.
+        """Available whenever the device is connected and the zone still exists.
 
-        The signal is the robot's MQTT-reported map (announced during every
-        clean), falling back to the cloud isCurrentMap flag. When neither is
-        available (e.g. a freshly restarted Vis Nav on its dock — the v1 API
-        omits isCurrentMap) every zone button stays available. A button whose
-        zone was deleted in the MyDyson app is always unavailable.
+        Deliberately does NOT gray out buttons for maps the robot is not
+        currently on. The map-currency signal is only known mid-clean (the v1
+        API omits isCurrentMap while docked), so gating availability on it made
+        every other-map button flip unavailable→available on each clean, churning
+        the logbook with spurious entries. Wrong-map presses are still blocked at
+        press time by async_press, which fails closed during a clean and open
+        when currency is unknown. A button whose zone was deleted in the MyDyson
+        app stays unavailable.
         """
         if self._zone_deleted:
             return False
-        if not super().available:
-            return False
-        from .services import _effective_current_map, _persistent_map_cache
-
-        maps = _persistent_map_cache.get_stale(self.coordinator.serial_number) or []
-        current = _effective_current_map(maps, self.coordinator)
-        return current is None or current.id == self._pmap_id
+        return super().available
 
     async def async_press(self) -> None:
         if self._zone_deleted:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -874,8 +874,17 @@ class TestDysonZoneCleanButton:
 
         mock_robot_coordinator.device.robot_start_clean.assert_called_once()
 
-    def test_available_false_when_other_map_is_current(self, mock_robot_coordinator):
-        """Button is unavailable while the cloud flags a different map current."""
+    def test_available_true_even_when_other_map_is_current(
+        self, mock_robot_coordinator
+    ):
+        """A non-current map's button stays available (no per-clean churn).
+
+        Gating availability on map currency made every other-map button flip
+        unavailable→available on each clean, spamming the logbook. The button
+        now stays available even when the cloud flags a different map current;
+        the cross-map command is still blocked at press time (see the
+        async_press guard tests).
+        """
         cached_maps = [
             PersistentMapMeta(
                 id="pmap-2",
@@ -891,10 +900,19 @@ class TestDysonZoneCleanButton:
         with patch(
             "custom_components.hass_dyson.services._persistent_map_cache", cache
         ):
-            assert btn.available is False
+            assert btn.available is True
 
-    def test_available_false_when_robot_reports_other_map(self, mock_robot_coordinator):
-        """The robot's own MQTT-reported map gates availability (no cloud flag)."""
+    def test_available_true_even_when_robot_reports_other_map(
+        self, mock_robot_coordinator
+    ):
+        """Mid-clean on another map, the button still reports available.
+
+        This is the scenario that previously produced the logbook churn: the
+        robot actively reports a different map, so the old gate flipped this
+        button unavailable for the duration of the clean. Availability no
+        longer depends on the map; the async_press guard still blocks the
+        cross-map command.
+        """
         cached_maps = [
             PersistentMapMeta(
                 id="pmap-1",
@@ -917,7 +935,7 @@ class TestDysonZoneCleanButton:
         with patch(
             "custom_components.hass_dyson.services._persistent_map_cache", cache
         ):
-            assert btn.available is False
+            assert btn.available is True
 
     def test_available_true_when_robot_on_own_map(self, mock_robot_coordinator):
         """A zone button on the robot's actively-reported map stays available."""


### PR DESCRIPTION
Fixes #413

## Problem

On multi-map robots (e.g. 360 Vis Nav), **every clean** spams the logbook / device
Activity feed with a batch of spurious zone-button state changes — rendered as
"… Clean <room> (<map>) pressed" — at the start and end of the clean. Nothing was
actually pressed; a user reading the Activity feed is led to think the robot tried
to clean a map/floor it didn't.

## Root cause

`DysonZoneCleanButton.available` gated on the robot's current map via
`_effective_current_map`. That signal is only known **mid-clean** — the v1
persistent-map API omits `isCurrentMap` while docked — so availability flapped once
per clean:

- docked / idle → currency unknown → all zone buttons available
- during a clean → the cleaning map is known → every **other-map** button flips **unavailable**
- clean ends → back to unknown → they flip **available** again

That per-clean `available`↔`unavailable` flip on the inactive map's buttons is what
the recorder logs and the Activity feed surfaces as "pressed".

## Fix

Drop the map-currency gate from `available()`; it now returns `super().available`
(device connected) unless the zone was deleted. Cross-map cleans are **still
blocked** at press time by `async_press`, which already fails closed during a clean
and open when currency is unknown (unchanged). Zone-deleted buttons still report
unavailable.

Trade-off: other-map buttons no longer visually gray out *during* a clean. Since the
press-time guard already prevents the mistaken command — and the map signal is
unreliable while docked anyway — the cosmetic gray-out isn't worth a per-clean
logbook churn.

## Testing

- Updated the two `available` unit tests to assert the non-churning behavior, keeping
  the "other map is current" setup so they remain genuine regression tests for the
  churn. The three `async_press` guard tests are unchanged and still pass.
- Verified on real hardware (360 Vis Nav): across a full scheduled clean, all
  inactive-map zone buttons held `available` with zero flips, the Activity feed showed
  no phantom "pressed" batch, and zone cleaning was unaffected.

Targets `release/v0.36.0`, which carries the multi-map zone buttons from #401 (the
code isn't in `main` yet).
