### PR TITLE
fix: reconcile robot fault sensors against the activeFaults snapshot

### DIFF
--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -1831,9 +1831,7 @@ class DysonDevice:
         if not isinstance(active_faults, list):
             return
         active_codes = {
-            entry.get("faultCode")
-            for entry in active_faults
-            if isinstance(entry, dict)
+            entry.get("faultCode") for entry in active_faults if isinstance(entry, dict)
         }
         faults = self._state_data.get("faults")
         if isinstance(faults, dict):

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -51,6 +51,7 @@ from .const import (
     DOMAIN,
     FAULT_TRANSLATIONS,
     MQTT_CMD_REQUEST_ENVIRONMENT,
+    ROBOT_FAULT_SUBSYSTEMS,
 )
 from .device_utils import mask_serial, mask_token
 
@@ -1585,6 +1586,7 @@ class DysonDevice:
         self._state_data.update(data)
         _LOGGER.debug("Updated device state for %s", self._log_serial)
 
+        self._reconcile_robot_faults(data.get("activeFaults"))
         self._update_robot_session(data.get("state") or data.get("newstate"))
 
         # Notify callbacks (including coordinator)
@@ -1809,8 +1811,63 @@ class DysonDevice:
             self._state_data["cleaningProgramme"] = programme
             if programme.get("persistentMapId"):
                 self._state_data["persistentMapId"] = programme["persistentMapId"]
+        self._clear_robot_faults(data.get("oldActiveFaults"))
         self._update_robot_session(data.get("newstate") or data.get("state"))
         _LOGGER.debug("State change for %s", self._log_serial)
+
+    def _reconcile_robot_faults(self, active_faults: Any) -> None:
+        """Apply an ``activeFaults`` snapshot to the retained ``faults`` dict.
+
+        The per-subsystem ``faults`` dict only rides fault-transition
+        STATE-CHANGE messages, so a clear that arrives while disconnected
+        (or is never re-sent) would latch a subsystem active forever.
+        CURRENT-STATE's ``activeFaults`` is an authoritative snapshot —
+        empty when healthy — so deactivate any retained subsystem whose
+        fault code is no longer listed. When the robot affirms nothing is
+        active and no ``faults`` dict has been seen yet (e.g. after a
+        restart), seed one so the fault sensors can report "off" instead
+        of sitting unknown until the next fault transition.
+        """
+        if not isinstance(active_faults, list):
+            return
+        active_codes = {
+            entry.get("faultCode")
+            for entry in active_faults
+            if isinstance(entry, dict)
+        }
+        faults = self._state_data.get("faults")
+        if isinstance(faults, dict):
+            for subsystem, entry in faults.items():
+                if (
+                    isinstance(entry, dict)
+                    and entry.get("active")
+                    and entry.get("description") not in active_codes
+                ):
+                    faults[subsystem] = {"active": False}
+        elif not active_codes:
+            self._state_data["faults"] = {
+                subsystem: {"active": False} for subsystem in ROBOT_FAULT_SUBSYSTEMS
+            }
+
+    def _clear_robot_faults(self, old_active_faults: Any) -> None:
+        """Deactivate retained subsystem faults named in ``oldActiveFaults``."""
+        if not isinstance(old_active_faults, list) or not old_active_faults:
+            return
+        faults = self._state_data.get("faults")
+        if not isinstance(faults, dict):
+            return
+        cleared_codes = {
+            entry.get("faultCode")
+            for entry in old_active_faults
+            if isinstance(entry, dict)
+        }
+        for subsystem, entry in faults.items():
+            if (
+                isinstance(entry, dict)
+                and entry.get("active")
+                and entry.get("description") in cleared_codes
+            ):
+                faults[subsystem] = {"active": False}
 
     # Robot states that end a clean/mapping session even though they carry
     # an active-looking prefix. FINISHED means the robot is back on (or at)

--- a/tests/test_robot_mqtt_replay.py
+++ b/tests/test_robot_mqtt_replay.py
@@ -17,6 +17,7 @@ import json
 import logging
 from pathlib import Path
 
+from custom_components.hass_dyson.const import ROBOT_FAULT_SUBSYSTEMS
 from custom_components.hass_dyson.device import DysonDevice
 
 FIXTURE = (
@@ -241,7 +242,153 @@ class TestRobotDetailRetention:
             "topic",
         )
         assert device.robot_active_faults == []
-        assert device.robot_faults is None  # dict only comes in STATE-CHANGE
+        # An empty snapshot also seeds the all-healthy faults dict so the
+        # subsystem sensors can restore to "off" instead of sitting unknown.
+        assert device.robot_faults["AIRWAYS"] == {"active": False}
 
     def test_no_programme_means_no_zones(self):
         assert _bare_device().robot_last_clean_zones == []
+
+
+class TestRobotFaultReconciliation:
+    """activeFaults snapshots repair the event-only per-subsystem faults dict.
+
+    The faults dict only rides fault-transition STATE-CHANGE messages, so a
+    clear that arrives while disconnected would otherwise latch a subsystem
+    active forever. Every heartbeat CURRENT-STATE carries the authoritative
+    ``activeFaults`` snapshot; ``oldActiveFaults`` clears immediately.
+    """
+
+    def _faulted_device(self) -> DysonDevice:
+        device = _bare_device()
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "oldstate": "INACTIVE_CHARGED",
+                "newstate": "FAULT_USER_RECOVERABLE",
+                "newActiveFaults": [
+                    {
+                        "faultCode": "7.0.-1",
+                        "nextActionRequired": "WAIT_TO_CLEAR",
+                        "present": "PRESENT",
+                        "requiredUserAction": "USER_RECOVERABLE",
+                    }
+                ],
+                "faults": {
+                    "AIRWAYS": {"active": True, "description": "7.0.-1"},
+                    "LIFT": {"active": False},
+                },
+            }
+        )
+        assert device.robot_faults["AIRWAYS"]["active"] is True
+        return device
+
+    def test_snapshot_clears_latched_fault(self):
+        """A missed fault clear self-heals on the next heartbeat snapshot."""
+        device = self._faulted_device()
+        device._handle_current_state(
+            {"msg": "CURRENT-STATE", "state": "INACTIVE_CHARGED", "activeFaults": []},
+            "topic",
+        )
+        assert device.robot_faults["AIRWAYS"] == {"active": False}
+        assert device.robot_faults["LIFT"] == {"active": False}
+
+    def test_snapshot_keeps_still_active_fault(self):
+        device = self._faulted_device()
+        device._handle_current_state(
+            {
+                "msg": "CURRENT-STATE",
+                "state": "FAULT_USER_RECOVERABLE",
+                "activeFaults": [
+                    {
+                        "faultCode": "7.0.-1",
+                        "nextActionRequired": "WAIT_TO_CLEAR",
+                        "present": "PRESENT",
+                        "requiredUserAction": "USER_RECOVERABLE",
+                    }
+                ],
+            },
+            "topic",
+        )
+        assert device.robot_faults["AIRWAYS"]["active"] is True
+
+    def test_empty_snapshot_seeds_all_subsystems_healthy(self):
+        """After a restart the fault sensors restore to off, not unknown."""
+        device = _bare_device()
+        device._handle_current_state(
+            {"msg": "CURRENT-STATE", "state": "INACTIVE_CHARGED", "activeFaults": []},
+            "topic",
+        )
+        assert device.robot_faults == {
+            subsystem: {"active": False} for subsystem in ROBOT_FAULT_SUBSYSTEMS
+        }
+
+    def test_populated_snapshot_does_not_seed(self):
+        """Codes cannot be mapped to subsystems without a retained description."""
+        device = _bare_device()
+        device._handle_current_state(
+            {
+                "msg": "CURRENT-STATE",
+                "state": "FAULT_USER_RECOVERABLE",
+                "activeFaults": [{"faultCode": "23.0.3"}],
+            },
+            "topic",
+        )
+        assert device.robot_faults is None
+
+    def test_missing_snapshot_is_a_no_op(self):
+        """CURRENT-STATE without activeFaults (purifiers) leaves the dict alone."""
+        device = self._faulted_device()
+        device._handle_current_state(
+            {"msg": "CURRENT-STATE", "state": "INACTIVE_CHARGED"}, "topic"
+        )
+        assert device.robot_faults["AIRWAYS"]["active"] is True
+
+    def test_malformed_entries_are_tolerated(self):
+        device = self._faulted_device()
+        device._state_data["faults"]["LIFT"] = "garbage"
+        device._handle_current_state(
+            {"msg": "CURRENT-STATE", "state": "INACTIVE_CHARGED", "activeFaults": []},
+            "topic",
+        )
+        assert device.robot_faults["AIRWAYS"] == {"active": False}
+        assert device.robot_faults["LIFT"] == "garbage"
+
+    def test_old_active_faults_clears_immediately(self):
+        """STATE-CHANGE oldActiveFaults clears without waiting for a heartbeat."""
+        device = self._faulted_device()
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "oldstate": "FAULT_USER_RECOVERABLE",
+                "newstate": "INACTIVE_CHARGED",
+                "oldActiveFaults": [{"faultCode": "7.0.-1"}],
+                "newActiveFaults": [],
+            }
+        )
+        assert device.robot_faults["AIRWAYS"] == {"active": False}
+
+    def test_old_active_faults_ignores_unrelated_codes(self):
+        device = self._faulted_device()
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "oldstate": "FAULT_USER_RECOVERABLE",
+                "newstate": "INACTIVE_CHARGED",
+                "oldActiveFaults": [{"faultCode": "23.0.3"}],
+                "newActiveFaults": [],
+            }
+        )
+        assert device.robot_faults["AIRWAYS"]["active"] is True
+
+    def test_old_active_faults_without_retained_dict_is_a_no_op(self):
+        device = _bare_device()
+        device._handle_state_change(
+            {
+                "msg": "STATE-CHANGE",
+                "oldstate": "FAULT_USER_RECOVERABLE",
+                "newstate": "INACTIVE_CHARGED",
+                "oldActiveFaults": [{"faultCode": "7.0.-1"}],
+            }
+        )
+        assert device.robot_faults is None


### PR DESCRIPTION
## Summary

Fixes #418.

The per-subsystem `faults` dict only rides fault-transition STATE-CHANGE messages — routine traffic and CURRENT-STATE never include it — so the retained copy that drives `DysonRobotFaultSensor` had no repair path. One missed fault-clear latched a subsystem `on` until the next fault on the same subsystem; observed live as an airways sensor stuck `on` for two days across two successful cleans after the robot had recovered.

## Changes

- **`_reconcile_robot_faults()`** — applied on every CURRENT-STATE: deactivates any retained subsystem whose fault code is absent from the `activeFaults` snapshot. This piggybacks on the existing 30-second heartbeat, mirroring how REQUEST-CURRENT-FAULTS already self-heals the purifier fault sensors each heartbeat — it brings the robot subsystem sensors in line with how every other fault surface in the integration recovers.
- **Restore seeding** — when the robot affirms `activeFaults: []` and no `faults` dict has been seen yet (e.g. after a restart), seed all subsystems inactive so the sensors restore to `off` instead of sitting `unknown` until the next fault transition. This settles the restore-semantics question left open on #412.
- **`_clear_robot_faults()`** — STATE-CHANGE `oldActiveFaults` entries clear their subsystem immediately, without waiting for the next heartbeat.

Clears happen only on positive evidence: a missing `activeFaults` key (purifiers, degraded payloads) is a no-op. A populated snapshot with no retained dict seeds nothing — fault codes can't be mapped to subsystems without a retained `description`.

## Tests

- New `TestRobotFaultReconciliation` (9 cases): snapshot clears a latched fault / keeps a still-active one, restore seeding, populated-snapshot no-seed, missing-snapshot no-op, malformed entry tolerance, and the three `oldActiveFaults` paths (clear, unrelated code, no retained dict).
- `test_active_faults_from_current_state` assertion deliberately flipped: an empty snapshot now seeds the all-healthy dict — that is the new restore behaviour, kept as a regression guard.

## Validation

Deployed on the affected instance (360 Vis Nav, cloud-connected): the latched airways sensor cleared on the first heartbeat after restart, all seven subsystem sensors report `off` after a restart (previously `unknown`), purifiers unaffected, no errors.

One assumption worth confirming when a real fault next occurs: that `activeFaults` stays populated for the full duration of an active fault. The community 277 capture shows entries carry `faultCode`/`requiredUserAction`/`nextActionRequired` while active, and `test_snapshot_keeps_still_active_fault` encodes the expectation.
