### PR TITLE
test: pin device connectivity in the robot button fixture (5 silent failures from #414)

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -46,6 +46,10 @@ def mock_robot_coordinator():
     coordinator.serial_number = "VS9-GB-HJA0000A"
     coordinator.device_name = "Vis Nav"
     coordinator.device = MagicMock()
+    # Pin real booleans so DysonEntity.available evaluates to True rather
+    # than returning the is_connected MagicMock (identity asserts need it).
+    coordinator.last_update_success = True
+    coordinator.device.is_connected = True
     coordinator.device_category = [DEVICE_CATEGORY_ROBOT]
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"auth_token": "tok"}


### PR DESCRIPTION
## Summary

Fixes the five `test_button.py::TestDysonZoneCleanButton::test_available_*` failures reported in #420 — these came from my #414 and have been failing (silently, per #420) since it merged. Cleaning up my own mess.

## Root cause

The tests flipped in #414 assert `button.available is True`. With the map-gate removed, `available` resolves to `DysonEntity.available`:

```python
return self.coordinator.last_update_success and (
    self.coordinator.device is not None and self.coordinator.device.is_connected
)
```

The `mock_robot_coordinator` fixture never pinned `last_update_success` or `device.is_connected`, so the expression returns the `is_connected` MagicMock (truthy, but not `True`), and the identity assertion can never pass. Before #414 the assertions happened to compare against the map-gate's real booleans, which is why this never showed earlier.

## Change

Pin both values in the fixture — it is meant to model a healthy, connected robot. Behaviour-neutral for every other consumer of the fixture: the mocks were already truthy, only their identity changes.

## Expected CI result

The branch baseline goes from `7 failed` to `2 failed` — the remaining two are the `test_find_follow.py` creation failures from #420. Note the Tests check will show green either way until the pipefail change from #420 lands; the real summary line is in the job log.
