### PR TITLE
fix: re-render dust map and floor plan when clean record or map version changes

### DIFF
--- a/custom_components/hass_dyson/coordinator.py
+++ b/custom_components/hass_dyson/coordinator.py
@@ -210,6 +210,21 @@ class TTLCache:
         """Remove *key* from the cache."""
         self._store.pop(key, None)
 
+    def invalidate_prefix(self, prefix: str) -> None:
+        """Remove every key that starts with *prefix* from the cache."""
+        for key in [k for k in self._store if k.startswith(prefix)]:
+            self._store.pop(key, None)
+
+    def expire_prefix(self, prefix: str) -> None:
+        """Expire every key that starts with *prefix* (see :meth:`expire`).
+
+        Unlike :meth:`invalidate_prefix` the values stay available through
+        :meth:`get_stale`, so callers with a stale-fallback path keep working
+        if the refetch after expiry fails.
+        """
+        for key in [k for k in self._store if k.startswith(prefix)]:
+            self.expire(key)
+
 
 class DysonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator for managing individual Dyson device state and communication.

--- a/custom_components/hass_dyson/image.py
+++ b/custom_components/hass_dyson/image.py
@@ -3,7 +3,12 @@
 Currently provides:
  - DysonDustMapImage:   the dust-density heatmap for the most recent clean
                         (rendered as PNG with purple→white gradient over the
-                        floor plan), refreshed when a new cleanId appears.
+                        floor plan), re-rendered whenever the record's dust
+                        data or the persistent map changes. Dyson updates the
+                        clean record IN PLACE while a clean is running (same
+                        cleanId, growing dust blob) and re-versions the
+                        persistent map afterwards, so a cleanId comparison
+                        would freeze the first (usually mid-clean) render.
  - DysonFloorPlanImage: the persistent-map presentation image (the static
                         floor plan with zone boundaries and dock location).
 
@@ -33,10 +38,12 @@ Bitmap rendering ported from thoukydides/matterbridge-dyson-robot
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
 import logging
 import zlib
 from datetime import datetime, timezone
+from functools import partial
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.config_entries import ConfigEntry
@@ -311,6 +318,23 @@ async def _fetch_persist_map(coordinator: DysonDataUpdateCoordinator, map_id: st
 
     _persist_map_cache.set(key, pmap)
     return pmap
+
+
+def _pmap_fingerprint(pmap) -> tuple | None:
+    """Content fingerprint of a persistent map for render-cache keys.
+
+    The robot re-versions the persistent map after cleans (new world offset,
+    dimensions and presentation bitmap). The model does not expose the map's
+    version number, so fingerprint the fields that change with it.
+    """
+    if not pmap:
+        return None
+    return (
+        pmap.offset_x,
+        pmap.offset_y,
+        pmap.display_orientation,
+        hashlib.sha1((pmap.presentation_map_data or "").encode()).hexdigest(),
+    )
 
 
 # ----------------------------------------------------------------------------
@@ -778,7 +802,7 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
         self._attr_unique_id = f"{coordinator.serial_number}_dust_map"
         self._attr_name = "Dust Map"
         self._attr_icon = "mdi:map-search"
-        self._cached_clean_id: str | None = None
+        self._render_cache_key: tuple | None = None
         self._cached_png: bytes | None = None
 
     @property
@@ -792,8 +816,6 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
             return None
         latest = cleans[0]
         clean_id = latest.clean_id
-        if clean_id and clean_id == self._cached_clean_id and self._cached_png:
-            return self._cached_png
 
         dust_map_model = getattr(latest, "dust_map", None)
         download_url = getattr(latest, "download_url", None)
@@ -813,6 +835,8 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
         # map, regardless of whether a download_url is present.
         # -------------------------------------------------------------------
         if not dust_map_model and clean_id:
+            if self._render_cache_key == ("v2", clean_id) and self._cached_png:
+                return self._cached_png
             # Strategy 1: Map Visualizer API (works for Vis Nav, 404 for RB05).
             png = await _fetch_map_image(self.coordinator, clean_id)
             # Strategy 2: v2 clean-maps-data endpoint (logs response for diagnostics).
@@ -827,7 +851,7 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
                     clean_id,
                 )
                 return None
-            self._cached_clean_id = clean_id
+            self._render_cache_key = ("v2", clean_id)
             self._cached_png = png
             self._attr_image_last_updated = datetime.now(timezone.utc)
             return png
@@ -837,6 +861,25 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
         # -------------------------------------------------------------------
         if not dust_map_model:
             return None
+
+        # Fingerprint the render inputs before deciding whether the cached
+        # PNG is still valid. Dyson updates the clean record in place during
+        # a clean and re-versions the persistent map afterwards, so the
+        # cleanId alone cannot tell a mid-clean snapshot from the final map.
+        try:
+            dust_blob = dust_map_model.dust_data[0].get("data") or ""
+        except (AttributeError, IndexError, TypeError):
+            dust_blob = ""
+        dust_fp = hashlib.sha1(dust_blob.encode()).hexdigest() if dust_blob else None
+
+        pmap = None
+        pmap_id = latest.persistent_map_id
+        if pmap_id:
+            pmap = await _fetch_persist_map(self.coordinator, pmap_id)
+
+        render_key = ("v1", clean_id, dust_fp, pmap_id, _pmap_fingerprint(pmap))
+        if render_key == self._render_cache_key and self._cached_png:
+            return self._cached_png
 
         # Convert DustMapData to the dict shape expected by _render_dust_map_png.
         dust_map_dict = {
@@ -858,18 +901,15 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
 
         presentation_png: bytes | None = None
         rotation_deg = 0
-        pmap_id = latest.persistent_map_id
-        if pmap_id:
-            pmap = await _fetch_persist_map(self.coordinator, pmap_id)
-            if pmap and pmap.presentation_map_data:
+        if pmap:
+            if pmap.presentation_map_data:
                 try:
                     presentation_png = base64.b64decode(pmap.presentation_map_data)
                 except (ValueError, TypeError):
                     presentation_png = None
-            if pmap:
-                rotation_deg = pmap.display_orientation
-                if pmap.offset_x is not None and pmap.offset_y is not None:
-                    map_offset_mm = (pmap.offset_x, pmap.offset_y)
+            rotation_deg = pmap.display_orientation
+            if pmap.offset_x is not None and pmap.offset_y is not None:
+                map_offset_mm = (pmap.offset_x, pmap.offset_y)
 
         cleaned_fp_png: bytes | None = None
         if latest.cleaned_footprint and latest.cleaned_footprint.data:
@@ -878,17 +918,22 @@ class DysonDustMapImage(DysonEntity, ImageEntity):
             except (ValueError, TypeError):
                 cleaned_fp_png = None
 
-        png = _render_dust_map_png(
-            dust_map_dict,
-            cleaned_fp_png,
-            presentation_png,
-            rotation_deg,
-            map_offset_mm=map_offset_mm,
-            clean_position_mm=clean_position_mm,
-            map_resolution_mm_per_px=resolution_mm_per_px,
+        # The renderer is pure-Python pixel loops over the full bitmap —
+        # run it in the executor so the event loop is not blocked.
+        png = await self.hass.async_add_executor_job(
+            partial(
+                _render_dust_map_png,
+                dust_map_dict,
+                cleaned_fp_png,
+                presentation_png,
+                rotation_deg,
+                map_offset_mm=map_offset_mm,
+                clean_position_mm=clean_position_mm,
+                map_resolution_mm_per_px=resolution_mm_per_px,
+            )
         )
         if png:
-            self._cached_clean_id = clean_id
+            self._render_cache_key = render_key
             self._cached_png = png
             self._attr_image_last_updated = datetime.now(timezone.utc)
         return png
@@ -921,7 +966,7 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
         self._attr_unique_id = f"{coordinator.serial_number}_floor_plan"
         self._attr_name = "Floor Plan"
         self._attr_icon = "mdi:floor-plan"
-        self._cached_pmap_id: str | None = None
+        self._render_cache_key: tuple | None = None
         self._cached_png: bytes | None = None
 
     @property
@@ -941,9 +986,6 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
                 self.coordinator.serial_number,
             )
             return None
-        if pmap_id == self._cached_pmap_id and self._cached_png:
-            return self._cached_png
-
         pmap = await _fetch_persist_map(self.coordinator, pmap_id)
         if not pmap:
             _LOGGER.warning(
@@ -964,6 +1006,9 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
                 self.coordinator.serial_number,
                 pmap_id,
             )
+            render_key = ("v2fp", pmap_id, cleans[0].clean_id)
+            if render_key == self._render_cache_key and self._cached_png:
+                return self._cached_png
             png = await _fetch_map_image(self.coordinator, pmap_id)
             if png is None:
                 _LOGGER.debug(
@@ -987,10 +1032,16 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
                         pmap_id,
                     )
                     return None
-            self._cached_pmap_id = pmap_id
+            self._render_cache_key = render_key
             self._cached_png = png
             self._attr_image_last_updated = datetime.now(timezone.utc)
             return png
+
+        # The map UUID never changes across map versions — fingerprint the
+        # map's content so post-clean re-versions replace the cached render.
+        render_key = ("v1fp", pmap_id, _pmap_fingerprint(pmap))
+        if render_key == self._render_cache_key and self._cached_png:
+            return self._cached_png
         try:
             png_in = base64.b64decode(pmap.presentation_map_data)
         except (ValueError, TypeError) as err:
@@ -1001,9 +1052,11 @@ class DysonFloorPlanImage(DysonEntity, ImageEntity):
             )
             return None
 
-        png = _render_presentation_png(png_in, pmap.display_orientation)
+        png = await self.hass.async_add_executor_job(
+            _render_presentation_png, png_in, pmap.display_orientation
+        )
         if png:
-            self._cached_pmap_id = pmap_id
+            self._render_cache_key = render_key
             self._cached_png = png
             self._attr_image_last_updated = datetime.now(timezone.utc)
         return png

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -1016,9 +1016,13 @@ class DysonDominantPollutantSensor(DysonEntity, SensorEntity):
 
 
 # Delay (seconds) between the robot reporting endOfClean and invalidating
-# the clean-maps cache. The cloud history entry was observed live within
-# ~2 minutes of endOfClean; the polling history/dust-map entities then pick
-# it up on their next update instead of waiting out the 30-minute TTL.
+# the clean-history caches. The cloud history entry was observed live within
+# ~2 minutes of endOfClean; the polling history sensors and the dust-map/
+# floor-plan images then pick it up on their next update instead of waiting
+# out the cache TTLs. The image-side caches must be dropped here as well —
+# the robot re-versions the persistent map (new offset/dimensions/bitmap)
+# after a clean, so a floor plan cached before the clean no longer matches
+# the coordinates in the fresh clean record.
 CLEAN_HISTORY_REFRESH_DELAY: float = 120.0
 
 
@@ -1045,12 +1049,21 @@ def _register_end_of_clean_listener(
     async def _async_refresh_history(_now) -> None:
         nonlocal refresh_unsub
         refresh_unsub = None
+        from .image import _floor_plan_cache, _map_image_cache, _persist_map_cache
         from .vacuum import _clean_maps_cache
 
-        _clean_maps_cache.invalidate(coordinator.serial_number)
+        serial = coordinator.serial_number
+        _clean_maps_cache.invalidate(serial)
+        prefix = f"{serial}:"
+        # expire (not invalidate): _fetch_persist_map falls back to get_stale
+        # on a failed refetch, so the pre-clean map must stay reachable.
+        _persist_map_cache.expire_prefix(prefix)
+        _floor_plan_cache.invalidate_prefix(prefix)
+        _map_image_cache.invalidate_prefix(prefix)
+        _recommended_cleans_cache.invalidate(serial)
         _LOGGER.debug(
-            "Clean finished on %s: history cache invalidated for refresh",
-            coordinator.serial_number,
+            "Clean finished on %s: history and map-image caches invalidated",
+            serial,
         )
 
     def _schedule_refresh() -> None:

--- a/tests/test_end_of_clean_refresh.py
+++ b/tests/test_end_of_clean_refresh.py
@@ -95,6 +95,38 @@ class TestEndOfCleanListener:
             await refresh_cb(None)
         cache.invalidate.assert_called_once_with(SERIAL)
 
+    @pytest.mark.asyncio
+    async def test_refresh_invalidates_image_and_recommendation_caches(self):
+        """The robot re-versions the persistent map after a clean, so the
+        image-side caches (floor plan, offsets, rendered maps) and the
+        recommended-cleans cache must be dropped alongside the history."""
+        hass, entry, coordinator = _hass(), _entry(), _coordinator()
+        with (
+            patch("custom_components.hass_dyson.sensor.async_call_later") as call_later,
+            patch("custom_components.hass_dyson.vacuum._clean_maps_cache"),
+            patch(
+                "custom_components.hass_dyson.image._persist_map_cache"
+            ) as persist_cache,
+            patch(
+                "custom_components.hass_dyson.image._floor_plan_cache"
+            ) as floor_cache,
+            patch(
+                "custom_components.hass_dyson.image._map_image_cache"
+            ) as map_img_cache,
+            patch(
+                "custom_components.hass_dyson.sensor._recommended_cleans_cache"
+            ) as rec_cache,
+        ):
+            _register_end_of_clean_listener(hass, entry, coordinator)
+            listener = coordinator.device.add_message_callback.call_args[0][0]
+            listener("topic", {"msg": "STATE-CHANGE", "endOfClean": True})
+            refresh_cb = call_later.call_args[0][2]
+            await refresh_cb(None)
+        persist_cache.expire_prefix.assert_called_once_with(f"{SERIAL}:")
+        floor_cache.invalidate_prefix.assert_called_once_with(f"{SERIAL}:")
+        map_img_cache.invalidate_prefix.assert_called_once_with(f"{SERIAL}:")
+        rec_cache.invalidate.assert_called_once_with(SERIAL)
+
     def test_repeated_end_of_clean_coalesces(self):
         hass, entry, coordinator = _hass(), _entry(), _coordinator()
         cancel = MagicMock()
@@ -138,3 +170,36 @@ class TestEndOfCleanListener:
             listener("topic", {"msg": "STATE-CHANGE", "endOfClean": True})
             entry.async_on_unload.call_args[0][0]()
         cancel.assert_called_once()
+
+
+class TestTTLCacheInvalidatePrefix:
+    def test_removes_only_matching_keys(self):
+        from custom_components.hass_dyson.coordinator import TTLCache
+
+        cache = TTLCache(3600)
+        cache.set(f"{SERIAL}:map-1", "a")
+        cache.set(f"{SERIAL}:map-2", "b")
+        cache.set("OTHER-SERIAL:map-1", "c")
+        cache.invalidate_prefix(f"{SERIAL}:")
+        assert cache.get(f"{SERIAL}:map-1") is None
+        assert cache.get_stale(f"{SERIAL}:map-1") is None
+        assert cache.get(f"{SERIAL}:map-2") is None
+        assert cache.get("OTHER-SERIAL:map-1") == "c"
+
+    def test_empty_cache_is_a_noop(self):
+        from custom_components.hass_dyson.coordinator import TTLCache
+
+        cache = TTLCache(3600)
+        cache.invalidate_prefix("anything:")
+        assert cache.get_stale("anything:x") is None
+
+    def test_expire_prefix_keeps_stale_fallback(self):
+        from custom_components.hass_dyson.coordinator import TTLCache
+
+        cache = TTLCache(3600)
+        cache.set(f"{SERIAL}:map-1", "a")
+        cache.set("OTHER-SERIAL:map-1", "c")
+        cache.expire_prefix(f"{SERIAL}:")
+        assert cache.get(f"{SERIAL}:map-1") is None
+        assert cache.get_stale(f"{SERIAL}:map-1") == "a"
+        assert cache.get("OTHER-SERIAL:map-1") == "c"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1561,6 +1561,54 @@ class TestDysonDustMapImage:
         assert mock_render.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_build_v2_reuses_cached_png_for_same_clean_id(self, mock_coordinator):
+        """The v2 path serves the cached PNG on a repeat build of the same cleanId."""
+        entity = self._make_entity(mock_coordinator)
+        record = _make_clean_record(
+            clean_id="clean-v2",
+            has_dust_map=False,
+            download_url="https://s3.example.com/map.bin",
+        )
+        rendered_png = b"\x89PNG dust"
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._fetch_map_image",
+                AsyncMock(return_value=rendered_png),
+            ) as mock_fetch_map_image,
+        ):
+            first = await entity._build()
+            second = await entity._build()
+        assert first == rendered_png
+        assert second is first
+        mock_fetch_map_image.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_build_tolerates_empty_dust_data(self, mock_coordinator):
+        """A record whose embedded dust map has no tiles yet uses an empty
+        fingerprint instead of raising on dust_data[0]."""
+        entity = self._make_entity(mock_coordinator)
+        record = _make_clean_record(pmap_id=None, position=None)
+        record.dust_map.dust_data = []
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._render_dust_map_png",
+                return_value=b"\x89PNG empty",
+            ),
+        ):
+            result = await entity._build()
+        assert result == b"\x89PNG empty"
+        assert entity._render_cache_key[:2] == ("v1", "clean-001")
+        assert entity._render_cache_key[2] is None
+
+    @pytest.mark.asyncio
     async def test_build_renders_without_persistent_map(self, mock_coordinator):
         """_build renders the dust map when no persistent map is available."""
         entity = self._make_entity(mock_coordinator)
@@ -1980,6 +2028,33 @@ class TestDysonFloorPlanImage:
         mock_fetch_map_image.assert_awaited_once_with(mock_coordinator, "pmap-2")
         assert entity._render_cache_key == ("v2fp", "pmap-2", "clean-001")
         assert entity._cached_png == rendered_png
+
+    @pytest.mark.asyncio
+    async def test_build_v2_floor_plan_reuses_cached_png(self, mock_coordinator):
+        """The v2 floor-plan fallback serves the cached PNG on a repeat build."""
+        entity = self._make_entity(mock_coordinator)
+        record = _make_clean_record(pmap_id="pmap-2")
+        pmap = _make_persistent_map(presentation_data=None)
+        rendered_png = b"\x89PNG floor"
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._fetch_persist_map",
+                AsyncMock(return_value=pmap),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._fetch_map_image",
+                AsyncMock(return_value=rendered_png),
+            ) as mock_fetch_map_image,
+        ):
+            first = await entity._build()
+            second = await entity._build()
+        assert first == rendered_png
+        assert second is first
+        mock_fetch_map_image.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_returns_none_for_invalid_base64(self, mock_coordinator):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1319,6 +1319,10 @@ class TestDysonDustMapImage:
         with self._PATCH_IMAGE_INIT, self._PATCH_DYSON_INIT:
             entity = DysonDustMapImage(MagicMock(), coordinator)
         entity.coordinator = coordinator
+        entity.hass = MagicMock()
+        entity.hass.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
         return entity
 
     def test_init_sets_unique_id(self, mock_coordinator):
@@ -1341,7 +1345,7 @@ class TestDysonDustMapImage:
     def test_init_cache_attrs_are_none(self, mock_coordinator):
         """Cache attributes start as None."""
         entity = self._make_entity(mock_coordinator)
-        assert entity._cached_clean_id is None
+        assert entity._render_cache_key is None
         assert entity._cached_png is None
 
     @pytest.mark.asyncio
@@ -1423,7 +1427,7 @@ class TestDysonDustMapImage:
             result = await entity._build()
         assert result == rendered_png
         mock_fetch_map_image.assert_awaited_once_with(mock_coordinator, "clean-v2")
-        assert entity._cached_clean_id == "clean-v2"
+        assert entity._render_cache_key == ("v2", "clean-v2")
         assert entity._cached_png == rendered_png
 
     @pytest.mark.asyncio
@@ -1497,24 +1501,64 @@ class TestDysonDustMapImage:
             result = await entity._build()
         assert result == fallback_png
         mock_fallback.assert_awaited_once_with(mock_coordinator, "clean-v2")
-        assert entity._cached_clean_id == "clean-v2"
+        assert entity._render_cache_key == ("v2", "clean-v2")
         assert entity._cached_png == fallback_png
 
     @pytest.mark.asyncio
-    async def test_build_uses_cached_png_for_same_clean_id(self, mock_coordinator):
-        """_build returns the cached PNG when the clean_id has not changed."""
-        entity = self._make_entity(mock_coordinator)
-        entity._cached_clean_id = "clean-001"
-        cached = b"\x89PNG fake"
-        entity._cached_png = cached
+    async def test_build_uses_cached_png_for_same_content(self, mock_coordinator):
+        """_build reuses the cached PNG only while the record content is unchanged.
 
-        record = _make_clean_record(clean_id="clean-001")
-        with patch(
-            "custom_components.hass_dyson.image.fetch_clean_maps",
-            AsyncMock(return_value=[record]),
+        Dyson updates the clean record in place during a clean (same cleanId,
+        growing dust blob), so a second build with identical content must not
+        re-render, but changed dust data under the same cleanId must.
+        """
+        entity = self._make_entity(mock_coordinator)
+        record = _make_clean_record(clean_id="clean-001", pmap_id=None, position=None)
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._render_dust_map_png",
+                return_value=b"\x89PNG one",
+            ) as mock_render,
         ):
-            result = await entity._build()
-        assert result is cached
+            first = await entity._build()
+            second = await entity._build()
+        assert first == b"\x89PNG one"
+        assert second is first
+        mock_render.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_build_rerenders_when_dust_data_changes(self, mock_coordinator):
+        """A mid-clean record updated in place (same cleanId) is re-rendered."""
+        entity = self._make_entity(mock_coordinator)
+        partial_rec = _make_clean_record(
+            clean_id="clean-001", pmap_id=None, position=None
+        )
+        final_rec = _make_clean_record(
+            clean_id="clean-001", pmap_id=None, position=None
+        )
+        final_rec.dust_map.dust_data = [
+            {
+                "data": base64.b64encode(zlib.compress(bytes(range(16, 32)))).decode(),
+                "scaleFactor": 255,
+            }
+        ]
+        fetch = AsyncMock(side_effect=[[partial_rec], [final_rec]])
+        with (
+            patch("custom_components.hass_dyson.image.fetch_clean_maps", fetch),
+            patch(
+                "custom_components.hass_dyson.image._render_dust_map_png",
+                side_effect=[b"\x89PNG partial", b"\x89PNG final"],
+            ) as mock_render,
+        ):
+            first = await entity._build()
+            second = await entity._build()
+        assert first == b"\x89PNG partial"
+        assert second == b"\x89PNG final"
+        assert mock_render.call_count == 2
 
     @pytest.mark.asyncio
     async def test_build_renders_without_persistent_map(self, mock_coordinator):
@@ -1533,7 +1577,8 @@ class TestDysonDustMapImage:
         ):
             result = await entity._build()
         assert result == b"\x89PNG rendered"
-        assert entity._cached_clean_id == "clean-001"
+        assert entity._render_cache_key is not None
+        assert entity._render_cache_key[:2] == ("v1", "clean-001")
         assert entity._cached_png == b"\x89PNG rendered"
 
     @pytest.mark.asyncio
@@ -1573,7 +1618,7 @@ class TestDysonDustMapImage:
         ):
             result = await entity._build()
         assert result is None
-        assert entity._cached_clean_id is None
+        assert entity._render_cache_key is None
 
     @pytest.mark.asyncio
     async def test_build_with_persistent_map_composites(self, mock_coordinator):
@@ -1713,6 +1758,10 @@ class TestDysonFloorPlanImage:
         with self._PATCH_IMAGE_INIT, self._PATCH_DYSON_INIT:
             entity = DysonFloorPlanImage(MagicMock(), coordinator)
         entity.coordinator = coordinator
+        entity.hass = MagicMock()
+        entity.hass.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
         return entity
 
     def test_init_sets_unique_id(self, mock_coordinator):
@@ -1735,7 +1784,7 @@ class TestDysonFloorPlanImage:
     def test_init_cache_attrs_are_none(self, mock_coordinator):
         """Cache attributes start as None."""
         entity = self._make_entity(mock_coordinator)
-        assert entity._cached_pmap_id is None
+        assert entity._render_cache_key is None
         assert entity._cached_png is None
 
     @pytest.mark.asyncio
@@ -1762,20 +1811,67 @@ class TestDysonFloorPlanImage:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_build_uses_cached_png_for_same_pmap_id(self, mock_coordinator):
-        """_build returns the cached PNG when pmap_id has not changed."""
-        entity = self._make_entity(mock_coordinator)
-        entity._cached_pmap_id = "pmap-1"
-        cached = b"\x89PNG cached"
-        entity._cached_png = cached
+    async def test_build_uses_cached_png_for_same_map_version(self, mock_coordinator):
+        """_build reuses the cached PNG only while the map content is unchanged.
 
+        The map UUID never changes across versions of the same map, so the
+        cache must key on the map's content: a second build with an identical
+        map must not re-render, but a re-versioned map (new offset/bitmap)
+        under the same UUID must.
+        """
+        entity = self._make_entity(mock_coordinator)
+        png_b64 = base64.b64encode(_make_png()).decode()
         record = _make_clean_record(pmap_id="pmap-1")
-        with patch(
-            "custom_components.hass_dyson.image.fetch_clean_maps",
-            AsyncMock(return_value=[record]),
+        pmap = _make_persistent_map(presentation_data=png_b64)
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._fetch_persist_map",
+                AsyncMock(return_value=pmap),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._render_presentation_png",
+                return_value=b"\x89PNG one",
+            ) as mock_render,
         ):
-            result = await entity._build()
-        assert result is cached
+            first = await entity._build()
+            second = await entity._build()
+        assert first == b"\x89PNG one"
+        assert second is first
+        mock_render.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_build_rerenders_when_map_reversioned(self, mock_coordinator):
+        """A re-versioned map (same UUID, new offset) is re-rendered."""
+        entity = self._make_entity(mock_coordinator)
+        png_b64 = base64.b64encode(_make_png()).decode()
+        record = _make_clean_record(pmap_id="pmap-1")
+        pmap_v5 = _make_persistent_map(presentation_data=png_b64)
+        pmap_v6 = _make_persistent_map(
+            presentation_data=png_b64, offset_x=-384.0, offset_y=-155.0
+        )
+        with (
+            patch(
+                "custom_components.hass_dyson.image.fetch_clean_maps",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._fetch_persist_map",
+                AsyncMock(side_effect=[pmap_v5, pmap_v6]),
+            ),
+            patch(
+                "custom_components.hass_dyson.image._render_presentation_png",
+                side_effect=[b"\x89PNG v5", b"\x89PNG v6"],
+            ) as mock_render,
+        ):
+            first = await entity._build()
+            second = await entity._build()
+        assert first == b"\x89PNG v5"
+        assert second == b"\x89PNG v6"
+        assert mock_render.call_count == 2
 
     @pytest.mark.asyncio
     async def test_build_returns_none_when_fetch_persist_map_fails(
@@ -1855,7 +1951,7 @@ class TestDysonFloorPlanImage:
             result = await entity._build()
         assert result == rendered_png
         mock_fp.assert_awaited_once_with(mock_coordinator, "clean-fp-id")
-        assert entity._cached_pmap_id == "pmap-2"
+        assert entity._render_cache_key == ("v2fp", "pmap-2", "clean-fp-id")
         assert entity._cached_png == rendered_png
 
     @pytest.mark.asyncio
@@ -1882,7 +1978,7 @@ class TestDysonFloorPlanImage:
             result = await entity._build()
         assert result == rendered_png
         mock_fetch_map_image.assert_awaited_once_with(mock_coordinator, "pmap-2")
-        assert entity._cached_pmap_id == "pmap-2"
+        assert entity._render_cache_key == ("v2fp", "pmap-2", "clean-001")
         assert entity._cached_png == rendered_png
 
     @pytest.mark.asyncio
@@ -1931,7 +2027,8 @@ class TestDysonFloorPlanImage:
         ):
             result = await entity._build()
         assert result == b"\x89PNG rendered"
-        assert entity._cached_pmap_id == "pmap-2"
+        assert entity._render_cache_key is not None
+        assert entity._render_cache_key[:2] == ("v1fp", "pmap-2")
         assert entity._cached_png == b"\x89PNG rendered"
 
     @pytest.mark.asyncio
@@ -1957,7 +2054,7 @@ class TestDysonFloorPlanImage:
         ):
             result = await entity._build()
         assert result is None
-        assert entity._cached_pmap_id is None
+        assert entity._render_cache_key is None
 
     @pytest.mark.asyncio
     async def test_build_updates_image_last_updated_on_success(self, mock_coordinator):


### PR DESCRIPTION
Fixes #422.

Dyson's cloud creates the clean-maps record while the clean is still running (same cleanId, dust blob growing in place) and re-versions the persistent map after the clean (new offset, dimensions and bitmap under the same map UUID). Caching the dust-map render per cleanId therefore freezes a mid-clean partial image until the next clean, and caching the floor plan per map UUID means it never re-renders at all.

- Key both render caches on a content fingerprint — dust blob hash plus map offset/orientation/bitmap — instead of cleanId / map UUID
- Extend the endOfClean invalidation to the persistent-map, floor-plan, map-image and recommended-cleans caches (new `TTLCache.invalidate_prefix`); the persistent-map cache is expired rather than invalidated so a failed post-clean refetch serves the previous map instead of blanking the image
- Run the pure-Python PNG renderers in the executor instead of the event loop
- Rewrote the test_image.py cases that asserted the per-cleanId freeze as desired behavior; added tests for the endOfClean cache refresh

Soaked live on a 360 Vis Nav: the dust map re-rendered three times during a nightly clean under one cleanId (record grew 5 min / 3.3 m² → 17 min / 12.6 m²), stayed correctly quiet through a recharge stop (fingerprint unchanged), and both images picked up a re-versioned persistent map in place with no restart. Fingerprint keying has a useful side effect: the dust map now live-updates during a clean as the cloud record grows.

Known gap: the v2 (RB05/Spot+Scrub) path still caches per cleanId at the entity level — I can't verify whether v2 records also update in place without an RB05 to test against.
