### PR TITLE
Add diagnostic IP address sensor for WiFi-connected devices

### DIFF
--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -25,6 +25,7 @@ Device Status Sensors:
     - Filter Life: HEPA and Carbon filter remaining life (0-100%)
     - Device Status: Overall device operational status
     - Connection Status: Local/Cloud/Disconnected
+    - IP Address: Host (IP address or hostname) used for the local connection
 
 Key Features:
     - Real-time data updates via MQTT streaming
@@ -1245,6 +1246,7 @@ async def async_setup_entry(  # noqa: C901
                 [
                     DysonWiFiSensor(coordinator),
                     DysonConnectionStatusSensor(coordinator),
+                    DysonIpAddressSensor(coordinator),
                 ]
             )
         else:
@@ -2901,6 +2903,49 @@ class DysonConnectionStatusSensor(DysonEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         # Connection status is updated directly from the device
+        super()._handle_coordinator_update()
+
+
+class DysonIpAddressSensor(DysonEntity, SensorEntity):
+    """Representation of a Dyson device's local network IP address/hostname.
+
+    Exposes the host currently used for the local MQTT connection, i.e. the
+    same value resolved by :meth:`DysonDataUpdateCoordinator._get_device_host`
+    (user-configured static IP/hostname, hostname reported by the cloud API,
+    or the ``{serial}.local`` mDNS fallback). This is a diagnostic entity
+    intended to help users confirm/troubleshoot local connectivity without
+    digging through logs.
+
+    Note:
+        Dyson devices do not expose their WiFi network MAC address via the
+        cloud API, local MQTT protocol, or mDNS service records used by this
+        integration, so no corresponding MAC address entity is provided. See
+        the device registry's ``connections`` field, which is Home
+        Assistant's canonical place for a MAC address, for context on why we
+        did not fabricate one there either.
+    """
+
+    coordinator: DysonDataUpdateCoordinator
+
+    def __init__(self, coordinator: DysonDataUpdateCoordinator) -> None:
+        """Initialize the IP address sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.serial_number}_ip_address"
+        self._attr_translation_key = "ip_address"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:ip-network"
+        self._attr_device_class = None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the IP address/hostname used for the local connection."""
+        if self.coordinator.device:
+            return getattr(self.coordinator.device, "host", None)
+        return None
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        # IP address is read directly from the device on each access
         super()._handle_coordinator_update()
 
 

--- a/custom_components/hass_dyson/translations/de.json
+++ b/custom_components/hass_dyson/translations/de.json
@@ -219,6 +219,9 @@
       "connection_status": {
         "name": "Verbindungsstatus"
       },
+      "ip_address": {
+        "name": "IP-Adresse"
+      },
       "filter_life": {
         "name": "{filter_type}-Filter Lebensdauer"
       },

--- a/custom_components/hass_dyson/translations/en.json
+++ b/custom_components/hass_dyson/translations/en.json
@@ -219,6 +219,9 @@
       "connection_status": {
         "name": "Connection Status"
       },
+      "ip_address": {
+        "name": "IP Address"
+      },
       "filter_life": {
         "name": "{filter_type} Filter Life"
       },

--- a/custom_components/hass_dyson/translations/fr.json
+++ b/custom_components/hass_dyson/translations/fr.json
@@ -219,6 +219,9 @@
       "connection_status": {
         "name": "État de connexion"
       },
+      "ip_address": {
+        "name": "Adresse IP"
+      },
       "filter_life": {
         "name": "Durée de vie du filtre {filter_type}"
       },

--- a/tests/test_sensor_class_coverage.py
+++ b/tests/test_sensor_class_coverage.py
@@ -16,12 +16,14 @@ Overall target: Reach 75% total coverage
 from unittest.mock import Mock, patch
 
 import pytest
+from homeassistant.const import EntityCategory
 
 from custom_components.hass_dyson.sensor import (
     DysonCarbonFilterLifeSensor,
     DysonConnectionStatusSensor,
     DysonFormaldehydeSensor,
     DysonHEPAFilterLifeSensor,
+    DysonIpAddressSensor,
     DysonNO2Sensor,
     DysonPM10Sensor,
     DysonPM25Sensor,
@@ -697,3 +699,60 @@ class TestConnectionStatusSensorErrorHandling:
             sensor._handle_coordinator_update()
 
         # Should handle gracefully
+
+
+class TestIpAddressSensorErrorHandling:
+    """Test error handling and basic behavior of DysonIpAddressSensor."""
+
+    def test_unique_id_and_diagnostic_category(self):
+        """Sensor should be a diagnostic entity with a stable unique id."""
+        coordinator = Mock()
+        coordinator.serial_number = "TEST-IP-000"
+        coordinator.device = None
+
+        sensor = DysonIpAddressSensor(coordinator)
+
+        assert sensor._attr_unique_id == "TEST-IP-000_ip_address"
+        assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_native_value_no_device(self):
+        """Test when coordinator has no device instance."""
+        coordinator = Mock()
+        coordinator.serial_number = "TEST-IP-001"
+        coordinator.device = None
+
+        sensor = DysonIpAddressSensor(coordinator)
+
+        assert sensor.native_value is None
+
+    def test_native_value_with_ip_host(self):
+        """Test retrieval of the resolved IP address used for the local connection."""
+        coordinator = Mock()
+        coordinator.serial_number = "TEST-IP-002"
+        coordinator.device = Mock()
+        coordinator.device.host = "192.168.1.42"
+
+        sensor = DysonIpAddressSensor(coordinator)
+
+        assert sensor.native_value == "192.168.1.42"
+
+    def test_native_value_with_hostname_fallback(self):
+        """Test retrieval when the device is addressed via mDNS hostname."""
+        coordinator = Mock()
+        coordinator.serial_number = "TEST-IP-003"
+        coordinator.device = Mock()
+        coordinator.device.host = "TEST-IP-003.local"
+
+        sensor = DysonIpAddressSensor(coordinator)
+
+        assert sensor.native_value == "TEST-IP-003.local"
+
+    def test_native_value_device_no_host_attr(self):
+        """Test graceful handling when device has no host attribute."""
+        coordinator = Mock()
+        coordinator.serial_number = "TEST-IP-004"
+        coordinator.device = Mock(spec=[])  # No attributes, incl. host
+
+        sensor = DysonIpAddressSensor(coordinator)
+
+        assert sensor.native_value is None

--- a/tests/test_sensor_setup_coverage.py
+++ b/tests/test_sensor_setup_coverage.py
@@ -507,6 +507,7 @@ class TestSensorSetupCategoryPaths:
         sensor_types = [type(entity).__name__ for entity in entities]
         assert "DysonWiFiSensor" in sensor_types
         assert "DysonConnectionStatusSensor" in sensor_types
+        assert "DysonIpAddressSensor" in sensor_types
 
     @pytest.mark.asyncio
     async def test_setup_wifi_sensors_for_robot_category(self):
@@ -533,6 +534,7 @@ class TestSensorSetupCategoryPaths:
         sensor_types = [type(entity).__name__ for entity in entities]
         assert "DysonWiFiSensor" in sensor_types
         assert "DysonConnectionStatusSensor" in sensor_types
+        assert "DysonIpAddressSensor" in sensor_types
 
     @pytest.mark.asyncio
     async def test_setup_no_wifi_sensors_for_other_categories(self):
@@ -559,6 +561,7 @@ class TestSensorSetupCategoryPaths:
         sensor_types = [type(entity).__name__ for entity in entities]
         assert "DysonWiFiSensor" not in sensor_types
         assert "DysonConnectionStatusSensor" not in sensor_types
+        assert "DysonIpAddressSensor" not in sensor_types
 
     @pytest.mark.asyncio
     async def test_setup_robot_category_battery_log(self):


### PR DESCRIPTION
Fixes #436

## Qué pide el issue

> Is it possible to add the devices IP/MAC details to the entities?

El maintainer (@cmgrayb) pidió confirmación de que se trataba de mostrar la IP y la MAC del dispositivo en la página del dispositivo, y el usuario original (@BassTeQ) confirmó:

> Yes that would be useful!

## Qué se implementó

Un nuevo sensor de diagnóstico `DysonIpAddressSensor` en `custom_components/hass_dyson/sensor.py`, que expone el host (IP, o hostname si se resuelve por el fallback mDNS `{serial}.local`) que la integración usa actualmente para la conexión MQTT local del dispositivo (`coordinator.device.host`, poblado por `DysonDataUpdateCoordinator._get_device_host`).

- `EntityCategory.DIAGNOSTIC`, habilitado por defecto — mismo patrón que `DysonWiFiSensor` y `DysonConnectionStatusSensor`, entidades diagnósticas ya existentes y habilitadas por defecto.
- Se crea solo para las categorías de dispositivo `"ec"` y `"robot"` (las que tienen conectividad WiFi), igual que las otras entidades de esta familia.
- Traducciones añadidas en `en.json`, `de.json` y `fr.json` para mantener paridad con el resto de sensores.

## Por qué esta forma y qué se descartó

**IP address → sensor de diagnóstico habilitado por defecto.** Consideré:
- **Atributo extra en otra entidad**: descartado porque Home Assistant está alejándose de `extra_state_attributes` para datos que el usuario querría en el historial/dashboard por separado; una entidad propia (como ya hacen `DysonWiFiSensor`/`DysonConnectionStatusSensor`) es el patrón idiomático de este repo.
- **Deshabilitado por defecto**: los sensores diagnósticos hermanos (WiFi signal, Connection Status) están habilitados por defecto en este repo, así que seguí la misma convención para consistencia, en vez de introducir un criterio distinto solo para este sensor.

**MAC address → NO implementado, intencionalmente.** Investigué de dónde salen los datos de conectividad en este repo:
- `coordinator.py::_get_device_host()` resuelve el host desde (1) IP/hostname estático configurado por el usuario, (2) el campo `hostname` del `device_info` del API cloud (`libdyson-rest`), o (3) el fallback mDNS `{serial}.local`. En ningún punto de esta cadena existe una dirección MAC de red WiFi.
- Revisé el paquete `libdyson-rest` (dependencia instalada, `grep -rn "mac"` sobre su código fuente) y no expone ningún campo de MAC.
- La resolución mDNS en `config_flow.py::_discover_device_via_mdns` solo lee `addresses` del `ServiceInfo` de zeroconf, no hay parsing de TXT records ni evidencia de que Dyson los publique.
- El único "MAC" que existe en el repo es `ble_mac`/`mac_address` en `ble_device.py`, que es la MAC **Bluetooth** de las lámparas Lightcycle Morph emparejadas por BLE — un dispositivo y flujo de datos completamente distinto al de este issue (purificadores/ventiladores conectados por WiFi/MQTT).

Dado que no existe ningún dato real de MAC de red para los dispositivos WiFi en el modelo de datos de esta integración (ni cloud API, ni MQTT local, ni mDNS), fabricar un valor sería incorrecto y potencialmente engañoso. Por eso no añadí:
- Una entidad `sensor` de MAC (no hay valor que mostrar).
- Un campo `connections` con MAC en el device registry (`device_info`), que es el sitio canónico de HA para una MAC — no tiene sentido registrar ahí un valor que la integración nunca puede obtener honestamente.

Si en el futuro se detecta una fuente real de la MAC (p. ej. si Dyson empieza a publicarla en TXT records de mDNS, o el cloud API la expone), sería sencillo añadir el mismo patrón de sensor diagnóstico, o incluso mejor, poblar `connections` en `device_info` para que HA la trate nativamente.

## Qué se validó

Regla de oro del equipo: escribir el test primero contra el código sin arreglar, confirmar que falla, e implementar después.

1. Escribí los tests **antes** de tocar `sensor.py`:
   - `tests/test_sensor_class_coverage.py::TestIpAddressSensorErrorHandling` (unique_id/categoría diagnóstica, `native_value` sin device, con IP, con hostname mDNS, y con device sin atributo `host`).
   - Extendí `tests/test_sensor_setup_coverage.py::TestSensorSetupCategoryPaths` (ya existente para WiFi/ConnectionStatus) para afirmar que `DysonIpAddressSensor` se crea en categorías `ec`/`robot` y NO se crea en otras categorías — ejercitando la ruta real de `async_setup_entry`, no un sustituto.
2. Corrí los tests nuevos contra el código sin el fix: fallo confirmado —
   - `ImportError: cannot import name 'DysonIpAddressSensor'` al recolectar `test_sensor_class_coverage.py`.
   - `test_setup_wifi_sensors_for_ec_category` y `test_setup_wifi_sensors_for_robot_category` fallan con `AssertionError` (`"DysonIpAddressSensor" not in sensor_types`).
3. Implementé el sensor y volví a correr: los 99 tests de esos dos archivos pasan.
4. Confirmación adicional con `git stash` de solo los archivos de implementación (`sensor.py` + 3 `translations/*.json`), dejando los tests nuevos en su sitio: la suite vuelve a fallar exactamente igual que en el paso 2, y al hacer `git stash pop` vuelve a pasar.
5. Suite completa: `python -m pytest` → **2692 passed, 1 skipped**, sin regresiones.
6. `ruff format --check`, `ruff check` y `mypy custom_components/hass_dyson/sensor.py` → sin issues sobre los archivos tocados.
7. `bandit` sobre `sensor.py` → mismos 2 issues preexistentes (línea 3791, código no tocado por este PR), nada nuevo introducido.

## Qué queda pendiente de validar con hardware

No tengo un purificador/ventilador Dyson real conectado. Todo lo anterior está validado con mocks siguiendo el patrón de test establecido en el repo, pero **necesito confirmación de un usuario con hardware real** de que:
- El nuevo sensor "IP Address" aparece en Configuración → Dispositivos → (dispositivo Dyson) → pestaña de diagnóstico, con el valor de IP correcto.
- El valor coincide con la IP/host real usado por la integración (visible también en los logs de depuración al conectar).
- Si el usuario configuró un hostname manual en vez de IP fija (ver `docs/DEVICE_MANAGEMENT.md`), el sensor debería reflejar ese hostname tal cual, no una IP resuelta — vale la pena que alguien lo confirme en un caso real de reconfiguración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
