### PR TITLE
fix(vacuum): map mid-cycle recharge states to DOCKED

### DIFF
--- a/custom_components/hass_dyson/const.py
+++ b/custom_components/hass_dyson/const.py
@@ -592,14 +592,16 @@ ROBOT_STATE_TO_HA_STATE: Final = {
     # Paused states
     ROBOT_STATE_FULL_CLEAN_PAUSED: VacuumActivity.PAUSED,
     ROBOT_STATE_MAPPING_PAUSED: VacuumActivity.PAUSED,
-    # Docked states
+    # Docked states — the robot is ON the dock. The *_CHARGING pair are
+    # mid-cycle recharges; .github/design/vacuums.md groups all five under
+    # "Dock and Charging States".
     ROBOT_STATE_INACTIVE_CHARGED: VacuumActivity.DOCKED,
     ROBOT_STATE_INACTIVE_CHARGING: VacuumActivity.DOCKED,
     ROBOT_STATE_INACTIVE_DISCHARGING: VacuumActivity.DOCKED,
-    # Returning states
+    ROBOT_STATE_FULL_CLEAN_CHARGING: VacuumActivity.DOCKED,
+    ROBOT_STATE_MAPPING_CHARGING: VacuumActivity.DOCKED,
+    # Returning states — en route to the dock, not on it yet
     ROBOT_STATE_FULL_CLEAN_FINISHED: VacuumActivity.RETURNING,
-    ROBOT_STATE_FULL_CLEAN_CHARGING: VacuumActivity.RETURNING,
-    ROBOT_STATE_MAPPING_CHARGING: VacuumActivity.RETURNING,
     ROBOT_STATE_FULL_CLEAN_ABORTED: VacuumActivity.RETURNING,
     ROBOT_STATE_FULL_CLEAN_NEEDS_CHARGE: VacuumActivity.RETURNING,
     ROBOT_STATE_MAPPING_NEEDS_CHARGE: VacuumActivity.RETURNING,

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -164,6 +164,9 @@ class TestDysonVacuumEntity:
             ("FULL_CLEAN_RUNNING", VacuumActivity.CLEANING),
             ("FULL_CLEAN_PAUSED", VacuumActivity.PAUSED),
             ("INACTIVE_CHARGED", VacuumActivity.DOCKED),
+            # Mid-cycle recharges: the robot is on the dock, not en route
+            ("FULL_CLEAN_CHARGING", VacuumActivity.DOCKED),
+            ("MAPPING_CHARGING", VacuumActivity.DOCKED),
             ("MAPPING_RUNNING", VacuumActivity.IDLE),
             ("FAULT_CRITICAL", VacuumActivity.ERROR),
             # States from the community-verified enum (matterbridge


### PR DESCRIPTION
Closes #439.

## Problem

`FULL_CLEAN_CHARGING` and `MAPPING_CHARGING` map to `VacuumActivity.RETURNING`, but the robot is on the dock in both. `.github/design/vacuums.md` already groups them with the three `INACTIVE_*` states:

```
#### Dock and Charging States
- INACTIVE_CHARGED     - Fully charged and ready for operation
- INACTIVE_CHARGING    - Actively charging at dock
- INACTIVE_DISCHARGING - On dock but not charging
- FULL_CLEAN_CHARGING  - Interrupted cleaning to recharge
- MAPPING_CHARGING     - Interrupted mapping to recharge
```

The first three map to `DOCKED`; the last two didn't.

Since 16243bc added `FULL_CLEAN_NEEDS_CHARGE`/`MAPPING_NEEDS_CHARGE` → `RETURNING` (correctly), "heading to the dock to charge" and "sitting on the dock charging" have both reported `RETURNING`, so the distinction is gone.

## Change

Two lines move from the returning block to the docked block. Resulting rule: `*_CHARGING` = on the dock; `*_NEEDS_CHARGE` / `*_FINISHED` / `*_ABORTED` = en route; `FAULT_ON_DOCK_*` stays `ERROR`.

## Impact

This is a user-visible behaviour change — automations keying on `returning` for a mid-clean recharge would need `docked`.

- `ROBOT_STATE_TO_HA_STATE` has one consumer, `DysonVacuum.activity`. The START-vs-RESUME `dock_states` set in `vacuum.py` matches raw state strings and is untouched, so `vacuum.start` still sends RESUME during a mid-clean recharge.
- `clean_id` and `full_clean_type` stay populated, so an unfinished clean is still distinguishable from an idle dock.
- Consistent with every HA core vacuum platform — roborock (`RoborockStateCode.charging: VacuumActivity.DOCKED`), ecovacs, tplink, switchbot, matter, xiaomi_miio, lg_thinq, smartthings. Roomba handles the same recharge-and-resume case the same way, noting in `roomba/vacuum.py` that a robot "docked to recharge mid-mission stays docked (the charging binary sensor distinguishes it from a user-initiated pause on the floor)".

## Testing

Two rows added to `test_vacuum.py::test_state_mapping`. Running on a 360 Vis Nav (H8W-AU-SGA5022B).

Independent of #438, but they pair well: that PR adds the charging binary sensor which carries the charging distinction once the activity no longer implies it. Either can merge first.