### PR TITLE
fix(climate): keep the heat setpoint on whole degrees

### DIFF
--- a/custom_components/hass_dyson/climate.py
+++ b/custom_components/hass_dyson/climate.py
@@ -18,7 +18,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, celsius_to_decikelvin, decikelvin_to_celsius
 from .coordinator import DysonDataUpdateCoordinator
 from .entity import DysonEntity
 
@@ -140,7 +140,7 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):  # type: ignore[misc]
                 # Only set temperature if we have a valid reading
                 if temp_kelvin > 0:
                     self._attr_current_temperature = round(
-                        temp_kelvin - 273.15, 1
+                        decikelvin_to_celsius(float(current_temp)), 1
                     )  # Convert to Celsius
                 else:
                     self._attr_current_temperature = None
@@ -157,7 +157,11 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):  # type: ignore[misc]
             temp_kelvin = int(target_temp) / 10
             # Only set target temperature if we have a valid reading
             if target_temp != "0000" and temp_kelvin > 0:
-                self._attr_target_temperature = temp_kelvin - 273.15
+                # Snap to the 1 degree step this entity advertises, otherwise the
+                # setpoint reads back a fraction of a degree off what was set.
+                self._attr_target_temperature = float(
+                    round(decikelvin_to_celsius(int(target_temp)))
+                )
             else:
                 self._attr_target_temperature = 20  # Default to 20°C
         except (ValueError, TypeError):
@@ -665,7 +669,7 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):  # type: ignore[misc]
 
         # Target temperature in Kelvin for device commands
         if target_temp is not None:
-            temp_kelvin: int = int((target_temp + 273.15) * 10)
+            temp_kelvin: int = celsius_to_decikelvin(target_temp)
             kelvin_str: str = f"{temp_kelvin:04d}"
             attributes["target_temperature_kelvin"] = kelvin_str  # type: ignore[assignment]
 

--- a/custom_components/hass_dyson/const.py
+++ b/custom_components/hass_dyson/const.py
@@ -770,3 +770,22 @@ BLE_MAX_KELVIN: Final = 6500  # coolest (≈ 154 mired)
 CONF_BLE_MAC: Final = "ble_mac"  # BLE MAC address (e.g. AA:BB:CC:DD:EE:FF)
 CONF_LTK: Final = "ltk"  # Long Term Key hex string (obtained via cloud pairing)
 CONF_BLE_PROXY: Final = "ble_proxy"  # Optional: pinned Bluetooth proxy host
+
+# Dyson reports and accepts temperatures as Kelvin x 10, e.g. "2890" = 289.0 K.
+ZERO_CELSIUS_IN_KELVIN: Final = 273.15
+
+
+def decikelvin_to_celsius(decikelvin: float) -> float:
+    """Convert a Dyson Kelvin x 10 temperature to degrees Celsius."""
+    return decikelvin / 10 - ZERO_CELSIUS_IN_KELVIN
+
+
+def celsius_to_decikelvin(celsius: float) -> int:
+    """Convert degrees Celsius to the Dyson Kelvin x 10 representation.
+
+    Rounds to the nearest step the device can hold. A whole number of degrees
+    Celsius never lands exactly on a tenth of a Kelvin (16 C is 2891.5), so the
+    value has to be rounded either way; truncating would always bias the stored
+    setpoint downwards.
+    """
+    return round((celsius + ZERO_CELSIUS_IN_KELVIN) * 10)

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -52,6 +52,7 @@ from .const import (
     FAULT_TRANSLATIONS,
     MQTT_CMD_REQUEST_ENVIRONMENT,
     ROBOT_FAULT_SUBSYSTEMS,
+    celsius_to_decikelvin,
 )
 from .device_utils import mask_serial, mask_token
 
@@ -3558,7 +3559,7 @@ class DysonDevice:
             raise ValueError("Target temperature must be between 1°C and 37°C")
 
         # Convert Celsius to Kelvin × 10 format for device
-        temp_value = int(temp_kelvin * 10)
+        temp_value = celsius_to_decikelvin(temperature)
         temp_str = f"{temp_value:04d}"
 
         await self.send_command(

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -53,8 +53,8 @@ from .const import (
     LEGACY_FILTER_LIFE_MAX_HOURS,
     MQTT_CMD_REQUEST_ENVIRONMENT,
     ROBOT_FAULT_SUBSYSTEMS,
-    celsius_to_decikelvin,
     STATE_KEY_LEGACY_FILTER_LIFE,
+    celsius_to_decikelvin,
 )
 from .device_utils import mask_serial, mask_token
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -356,7 +356,7 @@ class TestDysonClimateEntity:
         # Set target temperature from product state
         mock_coordinator.device.get_state_value.side_effect = (
             lambda state, key, default: {
-                "hmax": "3000",  # 26.85°C in 0.1K (300.0K)
+                "hmax": "3000",  # 300.0K, snapped to the 1 degree step -> 27°C
             }.get(key, default)
         )
 
@@ -368,7 +368,7 @@ class TestDysonClimateEntity:
         assert entity._attr_target_temperature is not None
         # 298.0K = 24.85°C, rounded to 1 decimal = 24.9°C
         assert entity._attr_current_temperature == 24.9
-        assert abs(entity._attr_target_temperature - 26.85) < 0.01
+        assert entity._attr_target_temperature == 27.0
 
     def test_update_temperatures_invalid_values(self, mock_coordinator):
         """Test temperature update with invalid device values."""
@@ -851,7 +851,7 @@ class TestClimateIntegration:
         # Set up product state with target temperature
         mock_coordinator.device.get_state_value.side_effect = (
             lambda state, key, default: {
-                "hmax": "3000",  # 26.85°C target (300.0K - 273.15)
+                "hmax": "3000",  # 300.0K, snapped to the 1 degree step -> 27°C
                 "fpwr": "ON",
                 "hmod": "HEAT",
             }.get(key, default)
@@ -866,7 +866,7 @@ class TestClimateIntegration:
         assert entity._attr_current_temperature is not None
         assert entity._attr_current_temperature == 21.9  # Rounded to 1 decimal
         assert entity._attr_target_temperature is not None
-        assert abs(entity._attr_target_temperature - 26.85) < 0.01
+        assert entity._attr_target_temperature == 27.0
 
         # Verify that the temperature is suitable for display on thermostat card
         assert isinstance(entity._attr_current_temperature, float)

--- a/tests/test_temperature_conversion.py
+++ b/tests/test_temperature_conversion.py
@@ -1,0 +1,93 @@
+"""Tests for the Kelvin x 10 temperature conversion used by the climate entity.
+
+Dyson stores the heat setpoint in ``hmax`` as Kelvin x 10, so a whole number of
+degrees Celsius never lands exactly on a value the device can hold (16 C is
+2891.5). These tests pin down that a setpoint written by the integration reads
+back as the same whole degree, which is what the entity's 1 degree step
+advertises.
+"""
+
+import pytest
+
+from custom_components.hass_dyson.const import (
+    ZERO_CELSIUS_IN_KELVIN,
+    celsius_to_decikelvin,
+    decikelvin_to_celsius,
+)
+
+# Every setpoint the climate entity accepts (min_temp 1, max_temp 37, step 1).
+SUPPORTED_SETPOINTS = list(range(1, 38))
+
+
+class TestDecikelvinToCelsius:
+    """Reading a raw device value."""
+
+    @pytest.mark.parametrize(
+        ("decikelvin", "expected"),
+        [
+            (2890, 15.85),
+            (2900, 16.85),
+            (3000, 26.85),
+            (2731.5, 0.0),
+        ],
+    )
+    def test_converts_using_absolute_zero(self, decikelvin, expected):
+        assert decikelvin_to_celsius(decikelvin) == pytest.approx(expected)
+
+    def test_matches_the_offset_constant(self):
+        assert decikelvin_to_celsius(ZERO_CELSIUS_IN_KELVIN * 10) == pytest.approx(0.0)
+
+
+class TestCelsiusToDecikelvin:
+    """Writing a setpoint to the device."""
+
+    @pytest.mark.parametrize(
+        ("celsius", "expected"),
+        [
+            (1, 2742),
+            (16, 2892),
+            (20, 2932),
+            (37, 3102),
+        ],
+    )
+    def test_rounds_to_nearest(self, celsius, expected):
+        assert celsius_to_decikelvin(celsius) == expected
+
+    def test_returns_an_int_for_the_wire_format(self):
+        value = celsius_to_decikelvin(20)
+        assert isinstance(value, int)
+        assert f"{value:04d}" == "2932"
+
+    def test_does_not_truncate_downwards(self):
+        """int() would store 2891 for 16 C, which reads back as 15.95."""
+        assert celsius_to_decikelvin(16) > int((16 + ZERO_CELSIUS_IN_KELVIN) * 10)
+
+
+class TestRoundTrip:
+    """The property that actually matters to the user."""
+
+    @pytest.mark.parametrize("celsius", SUPPORTED_SETPOINTS)
+    def test_setpoint_survives_a_write_then_read(self, celsius):
+        stored = celsius_to_decikelvin(celsius)
+        assert round(decikelvin_to_celsius(stored)) == celsius
+
+    @pytest.mark.parametrize("celsius", SUPPORTED_SETPOINTS)
+    def test_stays_within_half_a_degree_of_the_request(self, celsius):
+        assert (
+            abs(decikelvin_to_celsius(celsius_to_decikelvin(celsius)) - celsius) < 0.5
+        )
+
+    @pytest.mark.parametrize("celsius", SUPPORTED_SETPOINTS)
+    def test_repeated_round_trips_do_not_drift(self, celsius):
+        """Stepping the setpoint up and down must not accumulate an offset."""
+        value = float(celsius)
+        for _ in range(10):
+            value = float(round(decikelvin_to_celsius(celsius_to_decikelvin(value))))
+        assert value == celsius
+
+    @pytest.mark.parametrize("decikelvin", [2740, 2880, 2890, 2900, 3100])
+    def test_whole_kelvin_values_read_as_whole_degrees(self, decikelvin):
+        """Setpoints already on the device sit on whole Kelvin values."""
+        celsius = round(decikelvin_to_celsius(decikelvin))
+        assert celsius == pytest.approx(decikelvin_to_celsius(decikelvin), abs=0.5)
+        assert celsius == int(celsius)


### PR DESCRIPTION
The climate entity sets `_attr_target_temperature_step = 1`, so every setpoint a user can choose is a whole number of degrees. The value the entity reports back never is one.

Dyson keeps the setpoint in `hmax` as Kelvin x 10, and a whole number of degrees Celsius does not land on a tenth of a Kelvin. 16 C is 289.15 K, which is 2891.5 in the device format. The write path in `device.py` did `int(temp_kelvin * 10)`, so it truncated that to 2891, and the read path in `climate.py` subtracted 273.15 without snapping back to the step, giving 15.95. The setpoint therefore came back a fraction of a degree below what was asked for, every time.

What makes this more than a cosmetic rounding artefact is that the fraction is sticky. The thermostat card steps relative to the current target rather than to a whole number, so once a setpoint sat on a fractional value every subsequent adjustment carried the offset along. On my own Hot and Cool the target had settled at 15.85 and stepping up gave 16.85, then 17.85; the card showed 15.9, 16.9, 17.9 and could never reach a round figure again.

The same skew appears without touching Home Assistant at all. A device whose `hmax` was last set from the Dyson app sits on a whole Kelvin value, and 2890 is exactly 289.0 K. The previous code reported that as 15.85, displayed as 15.9, for what the app calls 16.

This change rounds on both sides rather than truncating on one. `celsius_to_decikelvin` rounds to the nearest value the device can actually hold, and the read snaps to the whole degree the entity's step already promises. Both directions now live in a pair of helpers in `const.py`, because the conversion was written out by hand in three places with slightly different arithmetic and had already drifted; the `target_temperature_kelvin` attribute recomputed it a third way. Ambient temperature is untouched, since `tact` is a measurement rather than a setpoint and keeps its tenth of a degree.

On the tests, `test_climate.py` had two assertions built on the old behaviour. Both use a fixture of `hmax: "3000"` with the comment `26.85°C`, which is the symptom itself written down: a whole Kelvin setpoint read back as a fraction. They now expect 27. `test_device.py` asserts `hmax == "2956"` for 22.5 C and still passes unchanged, since rounding and truncation agree there.

I added `tests/test_temperature_conversion.py` covering the round trip across the full supported range of 1 to 37 C, including a case that steps a setpoint through ten write/read cycles to pin down that no offset accumulates. Full suite is 2837 passed, 1 skipped, with ruff and mypy clean.

One thing worth flagging for review: I assumed the intent is that a whole degree chosen by the user should read back as that same whole degree, and rounded the read to make that true. If you would rather expose the device value at its native resolution, the alternative is to keep the read exact and instead set `_attr_target_temperature_step` to something the format can represent, but that changes what the UI offers and seemed the larger change of the two.