### PR TITLE
Support legacy filf filter life and reset

### DIFF
--- a/custom_components/hass_dyson/binary_sensor.py
+++ b/custom_components/hass_dyson/binary_sensor.py
@@ -228,22 +228,35 @@ class DysonFilterReplacementSensor(DysonEntity, BinarySensorEntity):  # type: ig
                         device_serial,
                     )
 
-                # Safely check HEPA filter
-                hepa_filter_type = (
-                    device_data.get("hflt", "NONE") if device_data else "NONE"
+                # Legacy devices provide filf without a filter type field. An
+                # explicit NONE remains authoritative when a type is present.
+                hepa_filter_type = device_data.get("hflt")
+                has_legacy_filter_life = "filf" in device_data
+                has_hepa_filter = hepa_filter_type not in (None, "NONE") or (
+                    hepa_filter_type is None and has_legacy_filter_life
                 )
-                if hepa_filter_type != "NONE":  # HEPA filter is installed
+                # Unavailable is only for a legitimately reported-but-unknown
+                # life (None); a malformed type or read error is a distinct
+                # defensive case and keeps the prior "no replacement" default.
+                has_unavailable_filter_life = False
+                if has_hepa_filter:
                     try:
                         hepa_life = getattr(
                             self.coordinator.device, "hepa_filter_life", None
                         )
-                        if hepa_life is not None and isinstance(hepa_life, int | float):
+                        if isinstance(hepa_life, int | float):
                             filters_to_check.append(hepa_life)
                             _LOGGER.debug(
                                 "HEPA filter life for device %s: %s%%",
                                 device_serial,
                                 hepa_life,
                             )
+                        elif hepa_life is None:
+                            _LOGGER.debug(
+                                "HEPA filter life unavailable for device %s",
+                                device_serial,
+                            )
+                            has_unavailable_filter_life = True
                         else:
                             _LOGGER.warning(
                                 "Invalid HEPA filter life data for device %s: %s",
@@ -269,6 +282,11 @@ class DysonFilterReplacementSensor(DysonEntity, BinarySensorEntity):  # type: ig
                         device_serial,
                         filters_to_check,
                         self._attr_is_on,
+                    )
+                elif has_unavailable_filter_life:
+                    self._attr_is_on = None
+                    _LOGGER.debug(
+                        "Filter life is unavailable for device %s", device_serial
                     )
                 else:
                     self._attr_is_on = False

--- a/custom_components/hass_dyson/const.py
+++ b/custom_components/hass_dyson/const.py
@@ -227,6 +227,7 @@ STATE_KEY_HEPA_FILTER_LIFE: Final = "hflr"  # HEPA filter life
 STATE_KEY_CARBON_FILTER_LIFE: Final = "cflr"  # Carbon filter life
 STATE_KEY_HEPA_FILTER_TYPE: Final = "hflt"  # HEPA filter type
 STATE_KEY_CARBON_FILTER_TYPE: Final = "cflt"  # Carbon filter type
+STATE_KEY_LEGACY_FILTER_LIFE: Final = "filf"  # Legacy filter life in hours
 STATE_KEY_SLEEP_TIMER: Final = "sltm"  # Sleep timer
 STATE_KEY_CONTINUOUS_MONITORING: Final = "rhtm"  # Continuous monitoring
 
@@ -278,6 +279,9 @@ STATE_KEY_FIND_FOLLOW_STATUS: Final = "sost"  # Find+Follow engine status (read-
 FILTER_TYPE_GCOM: Final = "GCOM"  # Genuine Combi Filter
 FILTER_TYPE_NONE: Final = "NONE"  # No filter installed
 FILTER_VALUE_INVALID: Final = "INV"  # Invalid/no filter
+
+# Filter protocol limits
+LEGACY_FILTER_LIFE_MAX_HOURS: Final = 4300
 
 # Connection status values
 CONNECTION_STATUS_LOCAL: Final = "Local"

--- a/custom_components/hass_dyson/device.py
+++ b/custom_components/hass_dyson/device.py
@@ -50,8 +50,10 @@ from .const import (
     DEVICE_CATEGORY_ROBOT,
     DOMAIN,
     FAULT_TRANSLATIONS,
+    LEGACY_FILTER_LIFE_MAX_HOURS,
     MQTT_CMD_REQUEST_ENVIRONMENT,
     ROBOT_FAULT_SUBSYSTEMS,
+    STATE_KEY_LEGACY_FILTER_LIFE,
 )
 from .device_utils import mask_serial, mask_token
 
@@ -2655,8 +2657,8 @@ class DysonDevice:
         return self._faults_data.get("product-warnings", {}).get("fltr", "Unknown")
 
     @property
-    def hepa_filter_life(self) -> int:
-        """Return HEPA filter life percentage."""
+    def hepa_filter_life(self) -> int | None:
+        """Return HEPA filter life percentage, or None when telemetry is unavailable."""
         try:
             product_state = self._state_data.get("product-state", {})
 
@@ -2684,22 +2686,37 @@ class DysonDevice:
                     except (ValueError, TypeError):
                         _LOGGER.warning("  Failed to convert fflr value: %s", fflr)
 
-            # Fall back to standard hflr field
-            hflr = product_state.get("hflr", "0000")
+            # Prefer the standard percentage field when it is available.
+            hflr = product_state.get("hflr")
             _LOGGER.debug("  Raw hflr value: %s (type: %s)", hflr, type(hflr))
 
             if hflr == "INV":  # Invalid/no filter installed
                 _LOGGER.debug("  HEPA filter marked as INV (invalid/no filter)")
-                return 0
+                return None
 
-            result = int(hflr)
-            _LOGGER.debug("  Converted hflr to int: %s", result)
+            if hflr is not None:
+                result = int(hflr)
+                _LOGGER.debug("  Converted hflr to int: %s", result)
+                return result
+
+            legacy_filter_life = product_state.get(STATE_KEY_LEGACY_FILTER_LIFE)
+            if legacy_filter_life is None:
+                return None
+
+            legacy_hours = int(legacy_filter_life)
+            clamped_hours = min(max(legacy_hours, 0), LEGACY_FILTER_LIFE_MAX_HOURS)
+            result = clamped_hours * 100 // LEGACY_FILTER_LIFE_MAX_HOURS
+            _LOGGER.debug(
+                "  Converted legacy filf value %s hours to %s%%",
+                legacy_filter_life,
+                result,
+            )
             return result
         except (ValueError, TypeError) as e:
             _LOGGER.warning(
                 "Failed to parse HEPA filter life for %s: %s", self._log_serial, e
             )
-            return 0
+            return None
 
     @property
     def carbon_filter_life(self) -> int | None:
@@ -3186,7 +3203,17 @@ class DysonDevice:
             await self.send_command("STATE-SET", {"fpwr": fpwr_value})
 
     async def reset_hepa_filter_life(self) -> None:
-        """Reset HEPA filter life to 100%."""
+        """Reset HEPA filter life using the device's reported protocol."""
+        product_state = self._state_data.get("product-state", {})
+        has_percentage_filter_life = "hflr" in product_state or "fflr" in product_state
+
+        if (
+            not has_percentage_filter_life
+            and STATE_KEY_LEGACY_FILTER_LIFE in product_state
+        ):
+            await self.send_command("STATE-SET", {"rstf": "RSTF"})
+            return
+
         await self.send_command("STATE-SET", {"hflr": "0100"})
 
     async def reset_carbon_filter_life(self) -> None:

--- a/custom_components/hass_dyson/sensor.py
+++ b/custom_components/hass_dyson/sensor.py
@@ -2756,11 +2756,13 @@ class DysonHEPAFilterTypeSensor(DysonEntity, SensorEntity):
 
         # Get HEPA filter type from device data
         device_data = self.coordinator.data.get("product-state", {})
-        filter_type = device_data.get("hflt", "NONE")
+        filter_type = device_data.get("hflt")
 
-        # Convert "NONE" to "Not Installed", otherwise return the actual type
+        # Only an explicit NONE value means no filter is installed.
         if filter_type == "NONE":
             self._attr_native_value = "Not Installed"
+        elif filter_type is None:
+            self._attr_native_value = None
         else:
             self._attr_native_value = filter_type
 

--- a/tests/test_binary_sensor_error_coverage.py
+++ b/tests/test_binary_sensor_error_coverage.py
@@ -72,7 +72,7 @@ class TestFilterReplacementSensorErrorHandling:
         assert sensor.is_on is False
 
     def test_handle_coordinator_update_none_hepa_life(self, mock_coordinator):
-        """Test _handle_coordinator_update with None HEPA filter life."""
+        """Test missing life for a reported filter is unknown."""
         sensor = DysonFilterReplacementSensor(mock_coordinator)
         mock_coordinator.data = {"product-state": {"hflt": "COMB"}}
         mock_coordinator.device.hepa_filter_life = None
@@ -80,7 +80,7 @@ class TestFilterReplacementSensorErrorHandling:
         with patch.object(sensor, "async_write_ha_state"):
             sensor._handle_coordinator_update()
 
-        assert sensor.is_on is False
+        assert sensor.is_on is None
 
     def test_handle_coordinator_update_exception_getting_hepa_life(
         self, mock_coordinator

--- a/tests/test_device_coverage_boost.py
+++ b/tests/test_device_coverage_boost.py
@@ -534,6 +534,32 @@ class TestFilterLifeCalculations:
         result = mock_device_basic.hepa_filter_life
         assert result == 100
 
+    @pytest.mark.parametrize(
+        ("legacy_hours", "expected_percentage"),
+        [("0000", 0), ("4299", 99), ("4300", 100)],
+    )
+    def test_hepa_filter_life_from_legacy_hours(
+        self, mock_device_basic, legacy_hours, expected_percentage
+    ):
+        """Test legacy filf hours convert to a truncated percentage."""
+        mock_device_basic._state_data = {"product-state": {"filf": legacy_hours}}
+
+        assert mock_device_basic.hepa_filter_life == expected_percentage
+
+    def test_hepa_filter_life_prefers_standard_percentage(self, mock_device_basic):
+        """Test hflr takes precedence over the legacy filf value."""
+        mock_device_basic._state_data = {
+            "product-state": {"hflr": "42", "filf": "4300"}
+        }
+
+        assert mock_device_basic.hepa_filter_life == 42
+
+    def test_hepa_filter_life_missing_is_unknown(self, mock_device_basic):
+        """Test missing filter telemetry does not appear as zero percent."""
+        mock_device_basic._state_data = {"product-state": {}}
+
+        assert mock_device_basic.hepa_filter_life is None
+
     def test_carbon_filter_life_calculation(self, mock_device_basic):
         """Test carbon filter life percentage calculation."""
         mock_device_basic._state_data = {"product-state": {"cflr": "70"}}
@@ -571,13 +597,45 @@ class TestFilterLifeCalculations:
 
     @pytest.mark.asyncio
     async def test_reset_hepa_filter_life(self, mock_device_basic):
-        """Test resetting HEPA filter life."""
+        """Test resetting a percentage-based HEPA filter life."""
         mock_device_basic._connected = True
         mock_device_basic.send_command = AsyncMock()
 
         await mock_device_basic.reset_hepa_filter_life()
 
-        mock_device_basic.send_command.assert_called_once()
+        mock_device_basic.send_command.assert_awaited_once_with(
+            "STATE-SET", {"hflr": "0100"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_reset_hepa_filter_life_uses_legacy_command(self, mock_device_basic):
+        """Test resetting a filf-based HEPA filter life."""
+        mock_device_basic._connected = True
+        mock_device_basic._state_data = {"product-state": {"filf": "4299"}}
+        mock_device_basic.send_command = AsyncMock()
+
+        await mock_device_basic.reset_hepa_filter_life()
+
+        mock_device_basic.send_command.assert_awaited_once_with(
+            "STATE-SET", {"rstf": "RSTF"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_reset_hepa_filter_life_prefers_percentage_protocol(
+        self, mock_device_basic
+    ):
+        """Test percentage telemetry retains the percentage reset command."""
+        mock_device_basic._connected = True
+        mock_device_basic._state_data = {
+            "product-state": {"hflr": "42", "filf": "4300"}
+        }
+        mock_device_basic.send_command = AsyncMock()
+
+        await mock_device_basic.reset_hepa_filter_life()
+
+        mock_device_basic.send_command.assert_awaited_once_with(
+            "STATE-SET", {"hflr": "0100"}
+        )
 
     @pytest.mark.asyncio
     async def test_reset_carbon_filter_life(self, mock_device_basic):

--- a/tests/test_legacy_filter_life.py
+++ b/tests/test_legacy_filter_life.py
@@ -1,0 +1,62 @@
+"""Tests for legacy Dyson filf filter-life telemetry."""
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.hass_dyson.binary_sensor import DysonFilterReplacementSensor
+from custom_components.hass_dyson.sensor import DysonHEPAFilterTypeSensor
+
+
+def test_legacy_filter_type_is_unknown() -> None:
+    """Test omitted hflt is not reported as not installed."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "TEST-LEGACY-001"
+    coordinator.data = {"product-state": {"filf": "4300"}}
+    coordinator.device = MagicMock()
+    sensor = DysonHEPAFilterTypeSensor(coordinator)
+
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+
+    assert sensor._attr_native_value is None
+
+
+def test_explicit_none_filter_type_is_not_installed() -> None:
+    """Test explicit hflt NONE remains not installed."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "TEST-LEGACY-002"
+    coordinator.data = {"product-state": {"hflt": "NONE", "filf": "4300"}}
+    coordinator.device = MagicMock()
+    sensor = DysonHEPAFilterTypeSensor(coordinator)
+
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+
+    assert sensor._attr_native_value == "Not Installed"
+
+
+def test_explicit_none_filter_type_skips_legacy_replacement_check() -> None:
+    """Test an explicit no-filter type overrides stale legacy life telemetry."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "TEST-LEGACY-004"
+    coordinator.data = {"product-state": {"hflt": "NONE", "filf": "0000"}}
+    coordinator.device.hepa_filter_life = 0
+    sensor = DysonFilterReplacementSensor(coordinator)
+
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+
+    assert sensor.is_on is False
+
+
+def test_legacy_filter_life_triggers_replacement() -> None:
+    """Test legacy filf data is evaluated without an hflt field."""
+    coordinator = MagicMock()
+    coordinator.serial_number = "TEST-LEGACY-003"
+    coordinator.data = {"product-state": {"filf": "0000"}}
+    coordinator.device.hepa_filter_life = 0
+    sensor = DysonFilterReplacementSensor(coordinator)
+
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+
+    assert sensor.is_on is True


### PR DESCRIPTION
## Summary

- Map legacy `product-state.filf` filter-life hours to a remaining percentage.
- Report absent legacy `hflt` telemetry as unknown rather than `Not Installed`.
- Use `rstf: "RSTF"` for HEPA reset on `filf` devices while retaining `hflr: "0100"` for percentage-based devices.
- Keep explicit `hflt: "NONE"` authoritative over stale `filf` telemetry.
- Report Filter Replacement as unknown when a reported filter has no usable life telemetry.

Fixes #445.

## Protocol Validation

Confirmed legacy `rstf: "RSTF"` reset behavior on below-maximum devices using both `mode-reason: "RAPP"` and `mode-reason: "LAPP"`:

- `RAPP`: `filf` changed from `4298` to `4300`
- `LAPP`: `filf` changed from `4299` to `4300`

The integration retains its existing generic `RAPP` command serialization.

## Testing

```text
32 focused pytest tests passed
Ruff format/lint and CRLF-aware diff checks passed
```
